### PR TITLE
ci: fix duplicate workflow runs and gate Docker by tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,13 @@ name: main
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+    tags: ['v*']
   pull_request:
-    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
## Summary
- Restrict push trigger to default branch + tags
- Remove branch filter from pull_request
- Add concurrency group to cancel superseded runs

## Test plan
- [ ] Verify PRs trigger CI once (not twice)
- [ ] Verify Docker push only happens on tag push