### PR TITLE
chore: guard push-go behind ALLOW_GO_PUSH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,9 @@ args — those leak through `docker history`):
 The Makefile builds the `GO_BUILD_SECRETS` list conditionally (`$(wildcard ...)`), so the
 go image builds with whatever subset is present. The go image's scripts read
 `/run/secrets/<id>` and fall back gracefully. NOTE: the go image still *contains* the
-operator's key material in its filesystem by design (a personal dev container) — keep go
-images private; CI does not build go.
+operator's key material in its filesystem by design (a personal dev container). CI does
+not build go, and **`make push-go` is blocked unless `ALLOW_GO_PUSH=1`** (and
+`build-push-all` excludes it) — keep go images on private registries only.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -213,8 +213,13 @@ build-go: check-env build-base
 run-go: check-env
 	@docker run --group-add "$$(stat -c '%g' /var/run/docker.sock)" -v /var/run/docker.sock:/var/run/docker.sock -v "$$(pwd)":/home/user/host_launchdir --name docker-ubuntu-go -it --rm $(IMAGE_GO_NAME) bash
 
-#push-go: @ Push go dev image to a registry
+#push-go: @ Push go dev image (BLOCKED by default — bakes operator creds; set ALLOW_GO_PUSH=1)
 push-go: login build-go
+	@[ "$$ALLOW_GO_PUSH" = "1" ] || { \
+		echo "ERROR: refusing to push the go image — it bakes operator SSH/GPG/PAT"; \
+		echo "       credentials into its filesystem. Publish ONLY to a PRIVATE registry,"; \
+		echo "       then re-run: make push-go ALLOW_GO_PUSH=1"; \
+		exit 1; }
 	@docker push $(IMAGE_GO_NAME)
 
 IMAGE_GO_CMD := docker images --filter=reference=$(IMAGE_GO_NAME) --format "{{.ID}}" | awk '{print $$1}'
@@ -240,8 +245,8 @@ endif
 #build-all: @ Build base + go + java images
 build-all: check-env build-base build-go build-java
 
-#build-push-all: @ Build and push all caches and images
-build-push-all: check-env build-base-inline-cache build-base push-base build-go push-go build-java-inline-cache build-java push-java
+#build-push-all: @ Build and push the publishable images (base + java; go is local-only)
+build-push-all: check-env build-base-inline-cache build-base push-base build-java-inline-cache build-java push-java
 
 #cleanup: @ Cleanup docker images, containers, volumes, networks, build cache
 cleanup: delete-go delete-java delete-base

--- a/README.md
+++ b/README.md
@@ -119,10 +119,11 @@ Run `make help` for the authoritative list.
 | `renovate-validate` | Validate `renovate.json` against the Renovate schema |
 | `build-base` / `run-base` / `push-base` / `delete-base` | Base image lifecycle |
 | `build-java` / `run-java` / `push-java` / `delete-java` | Java image lifecycle |
-| `build-go` / `run-go` / `push-go` / `delete-go` | Go image lifecycle |
+| `build-go` / `run-go` / `delete-go` | Go image lifecycle (built locally only) |
+| `push-go` | Push go image — **blocked unless `ALLOW_GO_PUSH=1`** (it bakes operator creds; private registries only) |
 | `build-base-inline-cache` / `build-java-inline-cache` | Build & push the registry inline cache |
 | `build-all` | Build base + go + java |
-| `build-push-all` | Build & push all caches and images |
+| `build-push-all` | Build & push the **publishable** images (base + java; go excluded) |
 | `cleanup` | Remove all images/layers/containers/volumes and prune build cache |
 
 ## Environment variables


### PR DESCRIPTION
## Summary
The **go** image bakes operator SSH/GPG/PAT credentials into its filesystem (by design — it's a personal dev container). This guards against accidentally publishing it:
- `make push-go` refuses unless `ALLOW_GO_PUSH=1`, with a clear message.
- `make build-push-all` drops `build-go`/`push-go` — it now pushes only the credential-free **base + java** images.
- README Make-targets table + CLAUDE.md updated.

## Test plan
- [x] guard refuses without flag, proceeds with `ALLOW_GO_PUSH=1` (verified)
- [x] `make help` / `make lint` green
- [ ] CI (docs+Makefile; Makefile isn't in paths-filter → build skipped, ci-pass green)