### PR TITLE
feat: upgrade base OS to Ubuntu 26.04 LTS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 Docker Ubuntu base image plus Java and Go development-environment variants, built on
-**Ubuntu 24.04 LTS**. Each image bundles a broad cloud-native / DevOps toolchain for use
+**Ubuntu 26.04 LTS**. Each image bundles a broad cloud-native / DevOps toolchain for use
 as a disposable dev container. All CLI tool versions are pinned and managed by **mise**.
 Images publish to **GHCR** (`ghcr.io/andriykalashnykov/...`).
 
@@ -81,7 +81,7 @@ not build go, and **`make push-go` is blocked unless `ALLOW_GO_PUSH=1`** (and
 Three independent build contexts, one per image, layered by `FROM`:
 
 ```
-ubuntu:24.04 (UBUNTU_VERSION)
+ubuntu:26.04 (UBUNTU_VERSION)
   └─ base/   → docker-ubuntu-base   (apt dev tools, Docker-in-Docker, mise + base toolchain)
        ├─ java/ → docker-ubuntu-java (Java 25 LTS / Maven / Gradle via mise, GCloud SDK, Cloud SQL Proxy)
        └─ go/   → docker-ubuntu-go   (Go toolchain & CLIs via mise, kubebuilder, GPG, PostgreSQL, GCloud SDK)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 # the per-image .mise.toml files (base/.mise.toml, java/.mise.toml, go/.mise.toml)
 # and managed by mise + Renovate — NOT here.
 # renovate: datasource=docker depName=ubuntu versioning=ubuntu
-UBUNTU_VERSION := 24.04
+UBUNTU_VERSION := 26.04
 
 ROOT_PWD := Docker!
 USER_UID := 1000

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ tool version is pinned and reproducible — see [TOOLING.md](./TOOLING.md).
 ## Image hierarchy
 
 ```
-ubuntu:24.04 (LTS)
+ubuntu:26.04 (LTS)
   └─ docker-ubuntu-base   base + DevOps toolchain (mise-managed) + Docker-in-Docker
        ├─ docker-ubuntu-java   + Java 25 LTS / Maven / Gradle, Google Cloud SDK, Cloud SQL Proxy
        └─ docker-ubuntu-go     + Go toolchain & dev CLIs, kubebuilder, goreleaser,
@@ -74,8 +74,8 @@ bind-mounts the host Docker socket (Docker-out-of-Docker) and the current direct
 The `base` and `java` images are published to GHCR — pull and run directly:
 
 ```bash
-docker run -it --rm ghcr.io/andriykalashnykov/docker-ubuntu-base:24.04 bash
-docker run -it --rm ghcr.io/andriykalashnykov/docker-ubuntu-java:24.04 bash
+docker run -it --rm ghcr.io/andriykalashnykov/docker-ubuntu-base:26.04 bash
+docker run -it --rm ghcr.io/andriykalashnykov/docker-ubuntu-java:26.04 bash
 ```
 
 ### Build a Java or Go app inside the container
@@ -86,20 +86,20 @@ Mount your project and run the toolchain. The entrypoint activates mise, so
 ```bash
 # Java (image ships Java 25 LTS, Maven 3.9, Gradle 9)
 docker run --rm -it -v "$PWD":/home/user/app -w /home/user/app \
-  ghcr.io/andriykalashnykov/docker-ubuntu-java:24.04 mvn -B package
+  ghcr.io/andriykalashnykov/docker-ubuntu-java:26.04 mvn -B package
 docker run --rm -it -v "$PWD":/home/user/app -w /home/user/app \
-  ghcr.io/andriykalashnykov/docker-ubuntu-java:24.04 gradle build
+  ghcr.io/andriykalashnykov/docker-ubuntu-java:26.04 gradle build
 
 # Go (image ships Go 1.26 + dlv, goreleaser, swag, goose, …) — build go locally first
 make build-go
 docker run --rm -it -v "$PWD":/home/user/app -w /home/user/app \
-  ghcr.io/andriykalashnykov/docker-ubuntu-go:24.04 go build ./...
+  ghcr.io/andriykalashnykov/docker-ubuntu-go:26.04 go build ./...
 docker run --rm -it -v "$PWD":/home/user/app -w /home/user/app \
-  ghcr.io/andriykalashnykov/docker-ubuntu-go:24.04 go test ./...
+  ghcr.io/andriykalashnykov/docker-ubuntu-go:26.04 go test ./...
 
 # …or open an interactive shell with your project mounted and work normally:
 docker run --rm -it -v "$PWD":/home/user/app -w /home/user/app \
-  ghcr.io/andriykalashnykov/docker-ubuntu-java:24.04 bash
+  ghcr.io/andriykalashnykov/docker-ubuntu-java:26.04 bash
 ```
 
 > The **go** image is built locally only (`make build-go`) — it is not published

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,7 @@
 # https://hub.docker.com/_/ubuntu/
 
 # renovate: datasource=docker depName=ubuntu versioning=ubuntu
-ARG UBUNTU_VERSION="24.04"
+ARG UBUNTU_VERSION="26.04"
 
 FROM ubuntu:$UBUNTU_VERSION
 
@@ -43,7 +43,7 @@ RUN apt-get install -y ca-certificates apt-utils software-properties-common curl
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/cache/apt \
     && rm -f /etc/ssh/ssh_host_* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+    && localedef -i en_US -c -f UTF-8 en_US.UTF-8
 
 # Docker-in-Docker via the official convenience script.
 # https://devopscube.com/run-docker-in-docker/

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,7 +2,7 @@
 # https://hub.docker.com/_/ubuntu/
 
 # renovate: datasource=docker depName=ubuntu versioning=ubuntu
-ARG UBUNTU_VERSION="24.04"
+ARG UBUNTU_VERSION="26.04"
 
 FROM ghcr.io/andriykalashnykov/docker-ubuntu-base:$UBUNTU_VERSION
 

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,7 +1,7 @@
 # https://hub.docker.com/_/ubuntu/
 
 # renovate: datasource=docker depName=ubuntu versioning=ubuntu
-ARG UBUNTU_VERSION="24.04"
+ARG UBUNTU_VERSION="26.04"
 
 FROM ghcr.io/andriykalashnykov/docker-ubuntu-base:$UBUNTU_VERSION
 


### PR DESCRIPTION
## Summary
Upgrades the base OS **Ubuntu 24.04 → 26.04 LTS** ("Resolute Raccoon"). Supersedes Renovate #79 (which was the bare tag bump without the build fix).

- `UBUNTU_VERSION` (Makefile) + all three Dockerfile `ARG` defaults → 26.04; docs/tags updated.
- **26.04 build fix:** `localedef -A /usr/share/locale/locale.alias` fails (that alias file is gone in 26.04) — dropped the optional `-A` arg (works on both releases). All base packages remain available; the 24.04 fixes (stock-user removal, named `USER`) carry over. The `systemd-resolved` resolv.conf warnings are non-fatal transitive-dep noise.

## Test plan
- [x] base/java/go all build on 26.04
- [x] base + java Trivy scans clean (OS CVEs + secrets, `--vuln-type os --scanners vuln,secret`)
- [x] smoke: Ubuntu 26.04 LTS, Java 25.0.3 + JAVA_HOME, go 1.26.3 + GOROOT, kubectl 1.36.1, passwordless sudo
- [x] `make ci` (lint + build-base) green
- [ ] CI on this PR (build + scan base & java)