### PR TITLE
chore: digest-pin ubuntu base + clean base Dockerfile hadolint + fix s2i renovate tracking

### DIFF
--- a/base/.mise.toml
+++ b/base/.mise.toml
@@ -24,7 +24,9 @@ opa       = "1.17.0"
 pack      = "0.40.6"          # Cloud Native Buildpacks (buildpacks/pack)
 ytt       = "0.55.0"          # Carvel ytt
 skaffold  = "2.21.0"
-"github:openshift/source-to-image" = { version = "1.6.1", exe = "s2i" }   # s2i (not in aqua registry)
+# s2i (not in aqua registry). `version_prefix = "v"` lets Renovate's mise manager
+# resolve upstream `v1.6.1` release tags against the v-less pin (emits extractVersion).
+"github:openshift/source-to-image" = { version = "1.6.1", exe = "s2i", version_prefix = "v" }
 
 # Misc
 yq        = "4.53.2"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,8 +2,14 @@
 
 # renovate: datasource=docker depName=ubuntu versioning=ubuntu
 ARG UBUNTU_VERSION="26.04"
+# Pinned digest of the ubuntu:${UBUNTU_VERSION} multi-arch manifest list — for
+# reproducibility/supply-chain. Renovate keeps it current via the renovate.json
+# customManager that captures the UBUNTU_VERSION tag + this digest together.
+# Kept separate from UBUNTU_VERSION because that var doubles as the published
+# image tag (docker-ubuntu-base:<ver>), which cannot carry an @sha256 suffix.
+ARG UBUNTU_DIGEST="sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64"
 
-FROM ubuntu:$UBUNTU_VERSION
+FROM ubuntu:${UBUNTU_VERSION}@${UBUNTU_DIGEST}
 
 ARG ROOT_PWD="Docker!"
 ARG USER_UID="1000"
@@ -25,16 +31,25 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 LABEL stage=$IMAGE_LABEL
 
+# Run RUN steps under bash with pipefail so a failure anywhere in a pipe
+# (curl … | sh, echo … | chpasswd) fails the build. Persists for all RUNs below.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Ubuntu 24.04+ ships a stock `ubuntu` user at UID/GID 1000 — remove it before
-# creating ours so the requested UID/GID is free.
+# creating ours so the requested UID/GID is free. `--no-log-init` avoids a huge
+# sparse lastlog/faillog file (hadolint DL3046).
 RUN (userdel -r ubuntu 2>/dev/null || true) \
     && (groupdel ubuntu 2>/dev/null || true) \
     && groupadd -g $USER_GID $USER_NAME \
-    && useradd -m -g $USER_GID -u $USER_UID --shell /bin/bash $USER_NAME
+    && useradd -m --no-log-init -g $USER_GID -u $USER_UID --shell /bin/bash $USER_NAME
 
-RUN apt-get update && apt-get install -y apt-transport-https
-
-RUN apt-get install -y ca-certificates apt-utils software-properties-common curl wget lsb-release sudo locales xclip xsel bash-completion \
+# Single apt layer: update once, install the curated toolset with
+# --no-install-recommends (DL3015), then clean the apt lists in the same layer
+# (DL3009). Verified the curated packages keep their real binaries under
+# --no-install-recommends (e.g. postgresql-client Depends: postgresql-client-18,
+# so psql is preserved; it is a Depends, not a Recommends).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https ca-certificates apt-utils software-properties-common curl wget lsb-release sudo locales xclip xsel bash-completion \
     vim nano zip unzip rar openssl ssh openssh-client tree git gitg git-lfs graphviz \
     gnupg gnupg2 net-tools jq httpie htop nmon iputils-ping html-xml-utils libxml2-utils xmlstarlet libnss3-tools slirp4netns \
     xdotool buildah podman skopeo postgresql-client make gcc python3-dev python3-pip python3-crcmod \
@@ -58,7 +73,9 @@ COPY ./scripts/ /home/$USER_NAME/scripts
 # Trivy flags it). A per-container key is generated at runtime by scripts/entry.sh
 # if none is mounted.
 
-RUN echo 'root:${ROOT_PWD}' | chpasswd
+# Double quotes so the ROOT_PWD build-arg actually expands (single quotes set
+# root's password to the literal string "${ROOT_PWD}" — SC2016, and a latent bug).
+RUN echo "root:${ROOT_PWD}" | chpasswd
 
 RUN chown -R $USER_UID:$USER_GID /home/$USER_NAME/
 
@@ -66,7 +83,6 @@ RUN chown -R $USER_UID:$USER_GID /home/$USER_NAME/
 # groups (sudo, docker) — required for passwordless sudo in downstream builds.
 USER $USER_NAME
 WORKDIR /home/$USER_NAME
-SHELL ["/bin/bash", "-c"]
 
 # --- Tool management via mise -------------------------------------------------
 # Tools are installed for the non-root user; the layer persists into the java/go
@@ -75,6 +91,10 @@ ENV MISE_DATA_DIR="/home/$USER_NAME/.local/share/mise"
 ENV PATH="/home/$USER_NAME/.local/bin:/home/$USER_NAME/.local/share/mise/shims:$PATH"
 RUN curl -fsSL https://mise.run | MISE_VERSION=$MISE_VERSION sh
 COPY --chown=$USER_UID:$USER_GID .mise.toml /home/$USER_NAME/.config/mise/config.toml
+# SC2016: the single quotes are intentional — the literal string
+# `eval "$(mise activate bash)"` must be written to .bashrc and evaluated per
+# shell at runtime, NOT expanded at build time.
+# hadolint ignore=SC2016
 RUN mise trust /home/$USER_NAME/.config/mise/config.toml \
     && mise install --yes \
     && mise reshim \

--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,19 @@
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+\\w+ := (?<currentValue>\\S+)"
       ],
       "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Keep the ubuntu base-image manifest-list digest (UBUNTU_DIGEST) in sync with the UBUNTU_VERSION tag in base/Dockerfile",
+      "managerFilePatterns": [
+        "/(^|/)base/Dockerfile$/"
+      ],
+      "matchStrings": [
+        "ARG UBUNTU_VERSION=\"(?<currentValue>[^\"]+)\"[\\s\\S]*?ARG UBUNTU_DIGEST=\"(?<currentDigest>sha256:[a-f0-9]+)\""
+      ],
+      "depNameTemplate": "ubuntu",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
Completes the three deferred items from #82 as **real, fact-checked fixes**. Verified by building **base + java + go** locally (all rc=0), `hadolint` clean on all three, `renovate-config-validator` pass, and a full tool smoke-test in the built base image.

## Item 2 — base/Dockerfile hadolint (10 findings → 0)
- **DL4006** (pipefail): one `SHELL ["/bin/bash","-o","pipefail","-c"]` near the top so piped `RUN`s fail properly; removed the later redundant non-pipefail `SHELL`.
- **DL3046**: `useradd --no-log-init` (no giant sparse lastlog/faillog).
- **DL3009 + DL3015**: merged the two `apt` layers into one `update && install --no-install-recommends … && clean` — also removes an orphaned apt-lists layer. **Verified** every curated tool keeps its binary under `--no-install-recommends`: `postgresql-client` **Depends** (not Recommends) on `postgresql-client-18`, so `psql` 18.4 survives; `gpg`, `dot`, `git-lfs`, `jq`, etc. all present.
- **SC2016 (real latent bug)**: `echo 'root:${ROOT_PWD}'` used single quotes → root's password was set to the literal string `${ROOT_PWD}`. Switched to double quotes so the ARG expands (confirmed `/etc/shadow` now holds a real hash). The mise-eval line keeps its intentional single quotes via a scoped `# hadolint ignore=SC2016`.

## Item 3 — digest-pin the ubuntu base
- Dedicated `UBUNTU_DIGEST` ARG (multi-arch **manifest-list** digest `sha256:f3d28607…`) + `FROM ubuntu:${UBUNTU_VERSION}@${UBUNTU_DIGEST}`. Build log confirms it resolves the pinned index digest.
- Kept separate from `UBUNTU_VERSION` because that var **doubles as the published image tag** (`docker-ubuntu-base:<ver>`) and cannot carry `@sha256`.
- Targeted renovate customManager captures the tag + digest together so Renovate keeps the seeded digest current (the reliable *update* path, per Renovate docs); aligns with `docker:pinDigests` from `config:best-practices`. Validated + regex confirmed to match.

## Item 4 — s2i renovate tracking
- Fact-check: Renovate's mise manager **does** track the `github:` backend (s2i was already tracked), but the pin `1.6.1` vs upstream `v1.6.1` tags wouldn't resolve under default semver. Added mise's `version_prefix = "v"`, which Renovate reads to emit the correct `extractVersion`. (aqua has no s2i package; `ubi:` was a no-benefit lateral move — both rejected on facts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)