### PR TITLE
refactor: inject go image credentials at runtime (no creds baked into the image)

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -16,7 +16,9 @@ ignored:
   # (which runs `mise activate`) before exec'ing the command. JSON-array form
   # cannot source a shell hook.
   - DL3025
-  # apt version pinning is impractical against the (currently EOL) Ubuntu
-  # release's archived repos; tracked instead via the "upgrade base OS" backlog
-  # item. Revisit after moving to a current LTS.
+  # DL3008 (pin apt package versions): impractical for a broad, frequently-updated
+  # dev toolchain — pinning ~40 packages to exact versions would fight Ubuntu
+  # security updates and break whenever the archive rotates a point release. The
+  # base image is rebuilt regularly (Renovate-tracked OS tag on a current LTS), so
+  # floating apt versions stay patched.
   - DL3008

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ make renovate-validate# Validate renovate.json against the schema
 make login            # Log in to GHCR (needs GITHUB_PAT with write:packages)
 make build-base       # Build base; build-java/build-go depend on this
 make build-java       # Build Java dev image (FROM base)
-make build-go         # Build Go dev image  (FROM base) — secrets via BuildKit mounts
+make build-go         # Build Go dev image  (FROM base) — credential-free; creds injected at run time
 make run-base|run-java|run-go   # docker run -it --rm <img> bash (run-go bind-mounts the docker socket and CWD, joins the host docker group via --group-add — DooD)
 make delete-base|delete-java|delete-go
 make build-all        # build-base + build-go + build-java
@@ -55,26 +55,26 @@ Key rules:
   (Go dev CLIs). Non-mise tools (apt packages, docker-engine, the multi-component gcloud
   SDK) stay on apt / official pinned installers — see TOOLING.md for the why.
 
-## Secrets (BuildKit secret mounts, not build args)
+## Secrets (runtime injection, not baked into the image)
 
-**base and java are secret-free** (base generates its own SSH key; java reuses the
-inherited one) — they build with no host secrets and are published from CI. Only the **go**
-image consumes operator secrets, and only via **BuildKit `--secret` mounts** (never build
-args — those leak through `docker history`):
+**All three images are credential-free at build time** — base, java, and go build with
+no host secrets, so any of them can be built anywhere (including CI). base generates its
+own SSH key; java reuses the inherited one. The **go** image's operator credentials
+(SSH/GPG/PAT) are injected **at container start** by `go/scripts/entry.sh`, from runtime
+bind-mounts / env supplied by `make run-go` — they never enter the image filesystem:
 
-| Secret id | Source | Absent → |
-|-----------|--------|----------|
-| `ssh_priv` / `ssh_pub` | `~/.ssh/id_rsa{,.pub}` | a fresh key is generated |
-| `gpg_secret` / `gpg_ownertrust` | `${DOTFILES_DIR}/gnupg/AndriyKalashnykov-*.{key,txt}` | GPG import skipped |
-| `gpg_pwd` | `$MY_GPG_PASSWORD` | GPG import skipped |
-| `github_pat` | `$GITHUB_PAT` | `.netrc` not written |
+| Credential | Runtime source (mounted/passed by `make run-go`) | In-container target | Absent → |
+|-----------|--------|--------|----------|
+| SSH key | `~/.ssh/id_rsa{,.pub}` → `/run/host-ssh/` (ro bind) | `~/.ssh/id_rsa{,.pub}` + `authorized_keys` | a fresh per-container key is generated |
+| GPG key | `${DOTFILES_DIR}/gnupg/AndriyKalashnykov-*.{key,txt}` → `/run/host-gpg/` (ro bind) | imported into `~/.gnupg` | GPG import skipped |
+| GPG passphrase | `$MY_GPG_PASSWORD` (`-e`, value from env) | used for the import | GPG import skipped |
+| GitHub PAT | `$GITHUB_PAT` (`-e`, value from env) | `~/.netrc` (0600) | `.netrc` not written |
 
-The Makefile builds the `GO_BUILD_SECRETS` list conditionally (`$(wildcard ...)`), so the
-go image builds with whatever subset is present. The go image's scripts read
-`/run/secrets/<id>` and fall back gracefully. NOTE: the go image still *contains* the
-operator's key material in its filesystem by design (a personal dev container). CI does
-not build go, and **`make push-go` is blocked unless `ALLOW_GO_PUSH=1`** (and
-`build-push-all` excludes it) — keep go images on private registries only.
+The Makefile builds the `GO_RUN_CREDS` mount/env list conditionally (`$(wildcard ...)` +
+`-e VAR` name-only, so secret VALUES never touch argv). Because the go image no longer
+contains operator credentials it is now safe to build/share, but it stays **local-only by
+policy** (a personal dev container layered on the published base+java): CI does not build
+go, **`make push-go` is blocked unless `ALLOW_GO_PUSH=1`**, and `build-push-all` excludes it.
 
 ## Architecture
 
@@ -88,9 +88,10 @@ ubuntu:26.04 (UBUNTU_VERSION)
 ```
 
 Each `<context>/` directory holds: a `Dockerfile`, a pinned `.mise.toml`, and a small
-`scripts/` dir (`entry.sh` activates mise; `go/scripts` also keeps
-`generate-ssh-keys.sh` / `generate-gpg-keys.sh`, which read `/run/secrets/*`). The old
-`install-*.sh` tool-fetch scripts were removed when mise took over.
+`scripts/` dir. `entry.sh` activates mise at container start; the **go** `entry.sh` also
+runs `generate-ssh-keys.sh` / `generate-gpg-keys.sh` then, setting up credentials from
+runtime bind-mounts (`/run/host-ssh`, `/run/host-gpg`) + env — nothing is baked into the
+image. The old `install-*.sh` tool-fetch scripts were removed when mise took over.
 
 ### Cross-cutting build mechanics
 
@@ -139,8 +140,11 @@ agent's prompt.
 
 - **Multi-arch** — images build `linux/amd64` only; add `linux/arm64` for Apple Silicon /
   Graviton (gcloud + some mise tools need arch-aware asset selection).
-- **go image credential surface** — the go image bakes operator SSH/GPG/PAT material into
-  its filesystem by design (personal dev container). Keep go images private; consider a
-  runtime-mount alternative if it ever needs to be shared.
-- **Publish go from CI** — currently local-only because it needs operator secrets; would
-  require GH secrets + a decision on the credential surface above.
+- **Publish go from CI** — now *unblocked* (the go image is credential-free; see "Secrets"
+  above). Still local-only by policy; enabling CI publish would only require adding go to
+  the build/push jobs — no secret-surface decision remains.
+
+### Resolved
+- **go image credential surface** — RESOLVED. Operator SSH/GPG/PAT are injected at
+  container start (`go/scripts/entry.sh` from `make run-go` runtime mounts/env), never
+  baked into the image filesystem.

--- a/Makefile
+++ b/Makefile
@@ -38,30 +38,39 @@ export DOCKER_BUILDKIT=1
 
 DOTFILES_DIR ?= $(HOME)/projects/dotfiles
 
-# The go image's secrets (GitHub PAT, GPG key material, SSH keys) are passed via
-# BuildKit secret mounts — NEVER build args (which leak via `docker history` and
-# argv). Each is included only when present on the host, so the build works
-# without them: the in-image scripts fall back (generate a fresh SSH key, skip
-# the GPG import). Secret VALUES never touch the command line — env secrets read
-# the inherited env; file secrets are streamed from disk by BuildKit.
-GO_BUILD_SECRETS :=
-ifneq ($(strip $(GITHUB_PAT)),)
-GO_BUILD_SECRETS += --secret id=github_pat,env=GITHUB_PAT
-endif
-ifneq ($(strip $(MY_GPG_PASSWORD)),)
-GO_BUILD_SECRETS += --secret id=gpg_pwd,env=MY_GPG_PASSWORD
-endif
-ifneq ($(wildcard $(DOTFILES_DIR)/gnupg/AndriyKalashnykov-secret-gpg.key),)
-GO_BUILD_SECRETS += --secret id=gpg_secret,src=$(DOTFILES_DIR)/gnupg/AndriyKalashnykov-secret-gpg.key
-endif
-ifneq ($(wildcard $(DOTFILES_DIR)/gnupg/AndriyKalashnykov-ownertrust-gpg.txt),)
-GO_BUILD_SECRETS += --secret id=gpg_ownertrust,src=$(DOTFILES_DIR)/gnupg/AndriyKalashnykov-ownertrust-gpg.txt
-endif
+# Runtime credential injection for the go image (`make run-go`). The image bakes
+# NO secrets — the operator's SSH/GPG keys and PAT are mounted/passed at CONTAINER
+# START and set up by go/scripts/entry.sh. Each is included only when present on
+# the host (so a bare run still works: a fresh SSH key is generated, GPG/PAT
+# skipped). Secret VALUES never touch argv: `-e` passes the var NAME (value
+# inherited from the env); file secrets are read-only bind mounts.
+# Per-file `$(wildcard ...)` guards are load-bearing: mounting a NON-existent host
+# path makes Docker create a root-owned empty dir at both ends, so only files that
+# actually exist are mounted. Both id_rsa and id_ed25519 are supported.
+GO_RUN_CREDS :=
 ifneq ($(wildcard $(HOME)/.ssh/id_rsa),)
-GO_BUILD_SECRETS += --secret id=ssh_priv,src=$(HOME)/.ssh/id_rsa
+GO_RUN_CREDS += -v $(HOME)/.ssh/id_rsa:/run/host-ssh/id_rsa:ro
 endif
 ifneq ($(wildcard $(HOME)/.ssh/id_rsa.pub),)
-GO_BUILD_SECRETS += --secret id=ssh_pub,src=$(HOME)/.ssh/id_rsa.pub
+GO_RUN_CREDS += -v $(HOME)/.ssh/id_rsa.pub:/run/host-ssh/id_rsa.pub:ro
+endif
+ifneq ($(wildcard $(HOME)/.ssh/id_ed25519),)
+GO_RUN_CREDS += -v $(HOME)/.ssh/id_ed25519:/run/host-ssh/id_ed25519:ro
+endif
+ifneq ($(wildcard $(HOME)/.ssh/id_ed25519.pub),)
+GO_RUN_CREDS += -v $(HOME)/.ssh/id_ed25519.pub:/run/host-ssh/id_ed25519.pub:ro
+endif
+ifneq ($(wildcard $(DOTFILES_DIR)/gnupg/AndriyKalashnykov-secret-gpg.key),)
+GO_RUN_CREDS += -v $(DOTFILES_DIR)/gnupg/AndriyKalashnykov-secret-gpg.key:/run/host-gpg/secret.key:ro
+endif
+ifneq ($(wildcard $(DOTFILES_DIR)/gnupg/AndriyKalashnykov-ownertrust-gpg.txt),)
+GO_RUN_CREDS += -v $(DOTFILES_DIR)/gnupg/AndriyKalashnykov-ownertrust-gpg.txt:/run/host-gpg/ownertrust.txt:ro
+endif
+ifneq ($(strip $(GITHUB_PAT)),)
+GO_RUN_CREDS += -e GITHUB_PAT
+endif
+ifneq ($(strip $(MY_GPG_PASSWORD)),)
+GO_RUN_CREDS += -e MY_GPG_PASSWORD
 endif
 
 # make sure docker is installed
@@ -216,20 +225,21 @@ CNT_DANGLING_CMD := docker volume ls -qf dangling=true
 CNT_DANGLING     := $(shell $(CNT_DANGLING_CMD) | wc -l)
 
 
-#build-go: @ Build go dev image (secrets via BuildKit secret mounts)
+#build-go: @ Build go dev image (no secrets — image is credential-free)
 build-go: check-env build-base
-	@docker build $(GO_BUILD_SECRETS) --build-arg IMAGE_LABEL=$(IMAGE_GO) --build-arg USER_EMAIL="$(USER_EMAIL)" --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) -t $(IMAGE_GO_NAME) ./go
+	@docker build --build-arg IMAGE_LABEL=$(IMAGE_GO) --build-arg USER_EMAIL="$(USER_EMAIL)" --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) -t $(IMAGE_GO_NAME) ./go
 
-#run-go: @ Run go dev image (mounts the docker socket via --group-add, no chmod)
+#run-go: @ Run go dev image (DooD socket + runtime-injected SSH/GPG/PAT creds)
 run-go: check-env
-	@docker run --group-add "$$(stat -c '%g' /var/run/docker.sock)" -v /var/run/docker.sock:/var/run/docker.sock -v "$$(pwd)":/home/user/host_launchdir --name docker-ubuntu-go -it --rm $(IMAGE_GO_NAME) bash
+	@docker run --group-add "$$(stat -c '%g' /var/run/docker.sock)" -v /var/run/docker.sock:/var/run/docker.sock -v "$$(pwd)":/home/user/host_launchdir $(GO_RUN_CREDS) --name docker-ubuntu-go -it --rm $(IMAGE_GO_NAME) bash
 
-#push-go: @ Push go dev image (BLOCKED by default — bakes operator creds; set ALLOW_GO_PUSH=1)
+#push-go: @ Push go dev image (BLOCKED by default — local-only by policy; set ALLOW_GO_PUSH=1)
 push-go: login build-go
 	@[ "$$ALLOW_GO_PUSH" = "1" ] || { \
-		echo "ERROR: refusing to push the go image — it bakes operator SSH/GPG/PAT"; \
-		echo "       credentials into its filesystem. Publish ONLY to a PRIVATE registry,"; \
-		echo "       then re-run: make push-go ALLOW_GO_PUSH=1"; \
+		echo "ERROR: the go image is local-only by project policy — a personal dev"; \
+		echo "       container layered on the published base+java, not part of the"; \
+		echo "       published set. (It no longer bakes operator credentials; SSH/GPG/PAT"; \
+		echo "       are injected at runtime by 'make run-go'.) To override: make push-go ALLOW_GO_PUSH=1"; \
 		exit 1; }
 	@docker push $(IMAGE_GO_NAME)
 

--- a/README.md
+++ b/README.md
@@ -43,17 +43,18 @@ The full strategy and the list of what is/ isn't mise-managed is documented in
 
 | Requirement | Notes |
 |-------------|-------|
-| [Docker](https://docs.docker.com/get-docker/) with BuildKit | `DOCKER_BUILDKIT=1`; `buildx` for `--secret` mounts |
+| [Docker](https://docs.docker.com/get-docker/) with BuildKit | `DOCKER_BUILDKIT=1` |
 | GNU Make | drives all build/run/push targets |
 | `GITHUB_PAT` (write:packages) | only for `make login` / `push-*` to GHCR |
 
-**base** and **java** build with no host secrets. The **go** image optionally
-consumes operator secrets via BuildKit secret mounts (it builds without them — a
-fresh SSH key is generated and the GPG import is skipped): an SSH key pair at
-`~/.ssh/id_rsa{,.pub}`, a GPG key pair at
+**All three images build with no host secrets** — the filesystem is credential-free.
+For the **go** image, the operator's credentials are injected **at container start**
+by `make run-go` (never baked into the image): the SSH key pair at
+`~/.ssh/id_rsa{,.pub}`, the GPG key pair at
 `${DOTFILES_DIR}/gnupg/AndriyKalashnykov-secret-gpg.key` + `…-ownertrust-gpg.txt`
 (`DOTFILES_DIR` defaults to `~/projects/dotfiles`), and the `GITHUB_PAT` /
-`MY_GPG_PASSWORD` env vars. These paths are owner-specific.
+`MY_GPG_PASSWORD` env vars — each used only if present (otherwise a fresh SSH key is
+generated and GPG/PAT setup is skipped). These paths are owner-specific.
 
 ```bash
 export GITHUB_PAT=<github-pat-with-write:packages>   # for `make login` / push to GHCR
@@ -124,7 +125,7 @@ Run `make help` for the authoritative list.
 | `build-base` / `run-base` / `push-base` / `delete-base` | Base image lifecycle |
 | `build-java` / `run-java` / `push-java` / `delete-java` | Java image lifecycle |
 | `build-go` / `run-go` / `delete-go` | Go image lifecycle (built locally only) |
-| `push-go` | Push go image — **blocked unless `ALLOW_GO_PUSH=1`** (it bakes operator creds; private registries only) |
+| `push-go` | Push go image — **blocked unless `ALLOW_GO_PUSH=1`** (local-only by policy; the image is credential-free) |
 | `build-base-inline-cache` / `build-java-inline-cache` | Build & push the registry inline cache |
 | `build-all` | Build base + go + java |
 | `build-push-all` | Build & push the **publishable** images (base + java; go excluded) |
@@ -134,8 +135,8 @@ Run `make help` for the authoritative list.
 
 | Variable | Purpose |
 |----------|---------|
-| `GITHUB_PAT` | GHCR auth (write:packages) for `login`/`push-*`; also injected into the **go** image `.netrc` (secret mount) |
-| `MY_GPG_PASSWORD` | GPG key passphrase for the **go** image (secret mount) |
+| `GITHUB_PAT` | GHCR auth (write:packages) for `login`/`push-*`; also injected into the **go** image `.netrc` at run time |
+| `MY_GPG_PASSWORD` | GPG key passphrase for the **go** image (passed to `make run-go` at run time) |
 | `DOTFILES_DIR` | Override the dotfiles path (default `~/projects/dotfiles`) |
 | `DOCKER_REGISTRY` | Override the publish registry (default `ghcr.io`) |
 
@@ -147,7 +148,7 @@ Run `make help` for the authoritative list.
   (build → Trivy image scan → tag-gated push (`:26.04` + `:latest` + `:sha-…`) →
   cosign keyless signing by digest → SBOM generation) → `ci-pass` (single required
   status check). PRs build and scan but do not push/sign. The **go** image is
-  built locally only (it needs operator secrets).
+  built locally only (a personal dev container; local-only by policy).
 - **Cleanup runs** ([`cleanup-runs.yml`](./.github/workflows/cleanup-runs.yml))
   — weekly prune of old workflow runs via the `gh` CLI.
 

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -37,44 +37,24 @@ COPY ./profile/ /home/$USER_NAME/
 COPY ./scripts/ /home/$USER_NAME/scripts
 RUN sudo chown -R $USER_UID:$USER_GID /home/$USER_NAME/
 
-# SSH keys — injected via BuildKit secret mounts when present on the host;
-# otherwise a fresh key is generated. Secrets never enter build args / layers.
-RUN --mount=type=secret,id=ssh_priv,uid=1000,required=false \
-    --mount=type=secret,id=ssh_pub,uid=1000,required=false \
-    /home/$USER_NAME/scripts/generate-ssh-keys.sh "$USER_NAME" "$USER_EMAIL"
-
+# Non-secret git + SSH host config baked at build time. Operator SSH/GPG/PAT
+# credentials are NOT baked into the image — scripts/entry.sh sets them up at
+# container start from runtime bind-mounts / env (`make run-go`), so the image
+# filesystem stays credential-free and is safe to build anywhere.
 RUN git lfs install \
-    && git config --global user.name $USER_NAME \
-    && git config --global user.email $USER_EMAIL \
-    && cat /home/$USER_NAME/.ssh/id_rsa.pub >> /home/$USER_NAME/.ssh/authorized_keys \
-    && chmod 755 /home/$USER_NAME/.ssh \
-    && chmod 600 /home/$USER_NAME/.ssh/authorized_keys /home/$USER_NAME/.ssh/id_rsa \
-    && chmod 644 /home/$USER_NAME/.ssh/id_rsa.pub \
+    && git config --global user.name "$USER_NAME" \
+    && git config --global user.email "$USER_EMAIL" \
+    && mkdir -p /home/$USER_NAME/.ssh \
     && ssh-keyscan -H github.com > /home/$USER_NAME/.ssh/known_hosts \
-    && printf 'Host github.com\n\tStrictHostKeyChecking no\n\tIdentityFile /home/%s/.ssh/id_rsa\n\tUpdateHostKeys yes\n' "$USER_NAME" >> /home/$USER_NAME/.ssh/config \
+    && printf 'Host github.com\n\tStrictHostKeyChecking no\n\tIdentityFile /home/%s/.ssh/id_ed25519\n\tIdentityFile /home/%s/.ssh/id_rsa\n\tUpdateHostKeys yes\n' "$USER_NAME" "$USER_NAME" >> /home/$USER_NAME/.ssh/config \
+    && chmod 700 /home/$USER_NAME/.ssh \
     && chmod 644 /home/$USER_NAME/.ssh/config /home/$USER_NAME/.ssh/known_hosts \
     && echo -e "\nexport TERM=$TERM" >> /home/$USER_NAME/.bashrc
-
-# GitHub PAT → ~/.netrc (for authenticated git/HTTPS). Mounted as a secret, so the
-# token never appears in build args or `docker history`.
-RUN --mount=type=secret,id=github_pat,uid=1000,required=false bash -c '\
-    if [ -s /run/secrets/github_pat ]; then \
-      PAT="$(cat /run/secrets/github_pat)"; \
-      printf "machine github.com\nlogin AndriyKalashnykov\npassword %s\n" "$PAT" >> "$HOME/.netrc"; \
-      printf "\nexport GITHUB_PAT=%s\n" "$PAT" >> "$HOME/.bashrc"; \
-      chmod 600 "$HOME/.netrc"; \
-    fi'
 
 # Go toolchain + Go dev CLIs + kubebuilder + goreleaser + cloud-sql-proxy via mise.
 # Merges on top of the base image's global mise config (full base toolset inherited).
 COPY --chown=$USER_UID:$USER_GID .mise.toml /home/$USER_NAME/.mise.toml
 RUN mise trust /home/$USER_NAME/.mise.toml && mise install --yes && mise reshim
-
-# GPG key material — imported via secret mounts when present; skipped otherwise.
-RUN --mount=type=secret,id=gpg_secret,uid=1000,required=false \
-    --mount=type=secret,id=gpg_ownertrust,uid=1000,required=false \
-    --mount=type=secret,id=gpg_pwd,uid=1000,required=false \
-    /home/$USER_NAME/scripts/generate-gpg-keys.sh "$USER_NAME"
 
 # Google Cloud SDK — pinned official installer.
 RUN curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" -o /tmp/gcloud.tgz \

--- a/go/scripts/entry.sh
+++ b/go/scripts/entry.sh
@@ -1,15 +1,41 @@
 #!/bin/bash
 #
 # Container entrypoint hook (sourced by the image ENTRYPOINT before the command).
-# Activates mise so every pinned tool is on PATH with its environment set
-# (JAVA_HOME, GOROOT, etc.) for non-interactive and interactive shells alike.
+#
+# 1) Activates mise so every pinned tool is on PATH with its environment set
+#    (GOROOT, JAVA_HOME, etc.) for non-interactive and interactive shells alike.
+# 2) Sets up operator credentials AT RUNTIME from bind-mounts / env injected by
+#    `make run-go`, so the IMAGE filesystem never contains SSH/GPG/PAT material.
+#    Bare `docker run` without those mounts still works: a fresh SSH key is
+#    generated and GPG/PAT setup is skipped.
+
+USER_NAME="${USER:-user}"
+SCRIPTS_DIR="/home/${USER_NAME}/scripts"
 
 if command -v mise >/dev/null 2>&1; then
     eval "$(mise activate bash --shims)"
-    # Export each active tool's env (JAVA_HOME, GOROOT, …) so they are set in
-    # non-interactive shells too, not only interactive ones (which get them via
-    # `mise activate` in ~/.bashrc).
+    # Export each active tool's env (GOROOT, …) so non-interactive shells get them
+    # too, not only interactive ones (which load it via ~/.bashrc).
     eval "$(mise env -s bash 2>/dev/null)"
 fi
+
+# --- Runtime credential setup — nothing here is baked into the image ---------
+if [ -x "${SCRIPTS_DIR}/generate-ssh-keys.sh" ]; then
+    "${SCRIPTS_DIR}/generate-ssh-keys.sh" "$USER_NAME" "${USER_EMAIL:-user@test.com}" || true
+fi
+if [ -x "${SCRIPTS_DIR}/generate-gpg-keys.sh" ]; then
+    "${SCRIPTS_DIR}/generate-gpg-keys.sh" || true
+fi
+# GitHub PAT -> ~/.netrc (authenticated git/HTTPS), only when provided at runtime.
+# Append the machine entry to whatever .netrc the image ships (a non-secret
+# template), but only if a github.com entry isn't already present (idempotent
+# across restarts). The token lives only in the running container, never the image.
+if [ -n "${GITHUB_PAT:-}" ] && ! grep -q '^machine github\.com' "${HOME}/.netrc" 2>/dev/null; then
+    umask 077
+    printf 'machine github.com\nlogin %s\npassword %s\n' \
+        "${GITHUB_USER:-AndriyKalashnykov}" "$GITHUB_PAT" >> "${HOME}/.netrc"
+    chmod 600 "${HOME}/.netrc"
+fi
+# -----------------------------------------------------------------------------
 
 lsb_release -a 2>/dev/null || true

--- a/go/scripts/generate-gpg-keys.sh
+++ b/go/scripts/generate-gpg-keys.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 #
-# Import GPG key material provided as BuildKit secret mounts:
-#   /run/secrets/gpg_secret      — the secret key (raw, ASCII-armored or binary)
-#   /run/secrets/gpg_ownertrust  — the ownertrust export
-#   /run/secrets/gpg_pwd         — the key passphrase
-# If any is missing, the import is skipped. No key material is ever a build arg.
+# Runtime GPG import — called by scripts/entry.sh at CONTAINER START (not at build
+# time). Key material is bind-mounted read-only at $GPG_SRC_DIR (default
+# /run/host-gpg) and the passphrase comes from the MY_GPG_PASSWORD env var, both
+# injected by `make run-go`. Skipped if absent. Nothing is baked into the image.
 
-USER_NAME=${1:-user}
+set -uo pipefail
 
-if [ -s /run/secrets/gpg_secret ] && [ -s /run/secrets/gpg_pwd ] && [ -s /run/secrets/gpg_ownertrust ]; then
-    echo "Importing provided GPG keys..."
-    GPG_PWD="$(cat /run/secrets/gpg_pwd)"
+GPG_SRC_DIR="${GPG_SRC_DIR:-/run/host-gpg}"
 
-    # https://unix.stackexchange.com/questions/60213/gpg-asks-for-password-even-with-passphrase
-    echo "$GPG_PWD" | gpg --batch --yes --passphrase-fd 0 --import /run/secrets/gpg_secret
-    gpg --import-ownertrust /run/secrets/gpg_ownertrust
-
-    gpg --batch=true --version
-    gpg --list-secret-keys --keyid-format=long || true
-    gpg --export-ownertrust || true
+if [ -s "${GPG_SRC_DIR}/secret.key" ] && [ -s "${GPG_SRC_DIR}/ownertrust.txt" ] && [ -n "${MY_GPG_PASSWORD:-}" ]; then
+    if gpg --list-secret-keys 2>/dev/null | grep -q '^sec'; then
+        echo "GPG secret key already present — skipping import."
+    else
+        echo "Importing operator GPG key from ${GPG_SRC_DIR} (runtime mount)..."
+        # https://unix.stackexchange.com/questions/60213
+        echo "$MY_GPG_PASSWORD" | gpg --batch --yes --passphrase-fd 0 --import "${GPG_SRC_DIR}/secret.key"
+        gpg --import-ownertrust "${GPG_SRC_DIR}/ownertrust.txt"
+        gpg --list-secret-keys --keyid-format=long || true
+    fi
 else
     echo "GPG key material not provided — skipping GPG import."
 fi

--- a/go/scripts/generate-ssh-keys.sh
+++ b/go/scripts/generate-ssh-keys.sh
@@ -1,23 +1,50 @@
 #!/bin/bash
 #
-# Install SSH keys into the user's ~/.ssh. Keys are provided as BuildKit secret
-# mounts (raw files at /run/secrets/ssh_priv and /run/secrets/ssh_pub); if absent,
-# a fresh key pair is generated. No key material is ever passed as a build arg.
+# Runtime SSH key setup — called by scripts/entry.sh at CONTAINER START (not at
+# build time). Operator keys are bind-mounted read-only at $SSH_SRC_DIR (default
+# /run/host-ssh) by `make run-go`; whichever standard key types are present
+# (id_rsa, id_ed25519, id_ecdsa) are copied in. If none are mounted, a fresh
+# throwaway RSA key is generated. No key material is ever baked into the image —
+# it exists only in the running container's writable layer.
 
-USER_NAME=${1:-user}
-USER_EMAIL=${2:-user@test.com}
+set -euo pipefail
 
-mkdir -p "/home/${USER_NAME}/.ssh"
+USER_NAME="${1:-${USER:-user}}"
+USER_EMAIL="${2:-user@test.com}"
+SSH_SRC_DIR="${SSH_SRC_DIR:-/run/host-ssh}"
+SSH_DIR="/home/${USER_NAME}/.ssh"
 
-if [ -s /run/secrets/ssh_priv ] && [ -s /run/secrets/ssh_pub ]; then
-    echo "Using provided SSH keys..."
-    cp /run/secrets/ssh_priv "/home/${USER_NAME}/.ssh/id_rsa"
-    cp /run/secrets/ssh_pub  "/home/${USER_NAME}/.ssh/id_rsa.pub"
-else
-    echo "Generating SSH keys..."
-    ssh-keygen -q -t rsa -b 4096 -N '' -C "$USER_EMAIL" -f "/home/${USER_NAME}/.ssh/id_rsa"
+mkdir -p "$SSH_DIR"
+
+copied=0
+if [ -d "$SSH_SRC_DIR" ]; then
+    for name in id_rsa id_ed25519 id_ecdsa; do
+        [ -s "${SSH_SRC_DIR}/${name}" ] || continue
+        echo "Using operator SSH key ${name} from ${SSH_SRC_DIR} (runtime mount)..."
+        cp "${SSH_SRC_DIR}/${name}" "${SSH_DIR}/${name}"
+        chmod 600 "${SSH_DIR}/${name}"
+        if [ -s "${SSH_SRC_DIR}/${name}.pub" ]; then
+            cp "${SSH_SRC_DIR}/${name}.pub" "${SSH_DIR}/${name}.pub"
+            chmod 644 "${SSH_DIR}/${name}.pub"
+        fi
+        copied=1
+    done
 fi
 
-chmod 700 "/home/${USER_NAME}/.ssh"
-chmod 600 "/home/${USER_NAME}/.ssh/id_rsa"
-chmod 644 "/home/${USER_NAME}/.ssh/id_rsa.pub"
+if [ "$copied" -eq 0 ] && [ ! -f "${SSH_DIR}/id_rsa" ]; then
+    echo "No operator SSH keys mounted — generating a fresh per-container key pair..."
+    ssh-keygen -q -t rsa -b 4096 -N '' -C "$USER_EMAIL" -f "${SSH_DIR}/id_rsa"
+fi
+
+chmod 700 "$SSH_DIR"
+
+# Allow ssh-ing into this container with whatever public keys are present
+# (idempotent — never duplicates a line).
+touch "${SSH_DIR}/authorized_keys"
+for pub in "${SSH_DIR}"/*.pub; do
+    [ -s "$pub" ] || continue
+    if ! grep -qxFf "$pub" "${SSH_DIR}/authorized_keys" 2>/dev/null; then
+        cat "$pub" >> "${SSH_DIR}/authorized_keys"
+    fi
+done
+chmod 600 "${SSH_DIR}/authorized_keys"


### PR DESCRIPTION
Implements the **runtime-injection** option for the go image's credential surface, plus the stale-DL3008-comment fix. The two "honest gaps" (Renovate digest customManager + s2i `version_prefix`) were **run-verified** via a live Renovate dry-run and needed no code change.

## go credential surface → runtime injection
Previously the go image baked the operator's **SSH private key, GPG secret key, and PAT** (`.netrc` + a `.bashrc` export) into its filesystem at build time. Now the image filesystem is **credential-free** (safe to build anywhere, including CI); `make run-go` injects creds at **container start**, preserving the workflow.

- **`go/scripts/entry.sh`** — after mise activate, sets up SSH/GPG from runtime bind-mounts (`/run/host-ssh`, `/run/host-gpg`) + env, then writes `~/.netrc` (0600) from `GITHUB_PAT`. Idempotent (append-guarded on an existing `machine github.com` line); the plaintext `.bashrc` PAT export is **removed**.
- **`generate-ssh-keys.sh`** — copies whichever key types are mounted (`id_rsa` / `id_ed25519` / `id_ecdsa`); fresh per-container RSA key only if none present; builds `authorized_keys` from all pubkeys.
- **`generate-gpg-keys.sh`** — imports from `/run/host-gpg` + `MY_GPG_PASSWORD`; skips cleanly when absent.
- **`go/Dockerfile`** — removed all three `--mount=type=secret` RUN blocks; only non-secret git/SSH host config is baked; ssh config lists both `id_ed25519` and `id_rsa`.
- **`Makefile`** — `GO_BUILD_SECRETS` → `GO_RUN_CREDS` (runtime `-v …:ro` + `-e VAR` name-only, so secret **values never touch argv**). Per-file `$(wildcard)` guards are load-bearing (mounting a missing path makes Docker create a root-owned empty dir). Supports `id_rsa` + `id_ed25519`.

### Verification (empirical)
- go builds **credential-free** (`rc=0`); image inspection: no baked priv key, no GPG secret, no `.netrc` password, no `authorized_keys`.
- End-to-end through the **real entrypoint**: operator `id_ed25519` injected at container start (perms 600), `authorized_keys` populated, `.netrc` github entry written (600), GPG gracefully skipped without a passphrase.
- Graceful bare-run fallback (fresh key, no GPG/PAT); **no host `~/.ssh` pollution**.
- `hadolint` (all 3) + `shellcheck` (the 3 changed scripts) + `make lint` clean.

> A test caught two real issues mid-implementation: (1) mounting a non-existent `id_rsa` made Docker create root-owned dirs in `~/.ssh` (fixed via `$(wildcard)` guards + cleanup); (2) the host uses `id_ed25519`, so an `id_rsa`-only design would never inject the real key — now both are supported.

This **unblocks "publish go from CI"** (the image is now CI-safe); go stays local-only by policy for now.

## DL3008 comment (minor/stale)
`.hadolint.yaml`'s DL3008 ignore rationale said "currently EOL Ubuntu / revisit after a current LTS" — stale now that we're on 26.04 LTS. Refreshed to the accurate kept reason (pinning ~40 dev packages fights security updates).

## Renovate run-verification (no change needed)
Live `renovate --platform=local --dry-run=lookup`: the digest customManager extracts ubuntu + did a real `getManifestResponse` on the pinned digest; s2i resolves with `extractVersion: ^v(?<version>.+)` from `version_prefix`, `updates: []`, no warnings. Both confirmed working against the live registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)