### PR TITLE
chore: remove gcloud SDK + Cloud SQL Proxy, swap rar→unrar (arm64-ready, amd64-only for now)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,6 @@ jobs:
           image-ref: ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/docker-ubuntu-base:${{ env.UBUNTU_VERSION }}
           vuln-type: os
           scanners: vuln,secret
-          skip-dirs: '**/google-cloud-sdk/platform/gsutil/third_party'
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: '1'
@@ -136,7 +135,6 @@ jobs:
           image-ref: ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/docker-ubuntu-java:${{ env.UBUNTU_VERSION }}
           vuln-type: os
           scanners: vuln,secret
-          skip-dirs: '**/google-cloud-sdk/platform/gsutil/third_party'
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: '1'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,10 @@ Key rules:
   variant inherits the full base toolset.
 - `entry.sh` runs `mise activate --shims` + `mise env` at container start, so tool env
   (`JAVA_HOME`, `GOROOT`, …) is set in interactive AND non-interactive shells.
-- Backends in use: core (kubectl, helm, go, java, …), `aqua:` (vivid, cloud-sql-proxy,
-  goreleaser), `github:` (s2i — not in the aqua registry; needs `exe = "s2i"`), `go:`
-  (Go dev CLIs). Non-mise tools (apt packages, docker-engine, the multi-component gcloud
-  SDK) stay on apt / official pinned installers — see TOOLING.md for the why.
+- Backends in use: core (kubectl, helm, go, java, …), `aqua:` (vivid, goreleaser),
+  `github:` (s2i — not in the aqua registry; needs `exe = "s2i"`), `go:`
+  (Go dev CLIs). Non-mise tools (apt packages, docker-engine) stay on apt / the official
+  pinned installer — see TOOLING.md for the why.
 
 ## Secrets (runtime injection, not baked into the image)
 
@@ -83,8 +83,8 @@ Three independent build contexts, one per image, layered by `FROM`:
 ```
 ubuntu:26.04 (UBUNTU_VERSION)
   └─ base/   → docker-ubuntu-base   (apt dev tools, Docker-in-Docker, mise + base toolchain)
-       ├─ java/ → docker-ubuntu-java (Java 25 LTS / Maven / Gradle via mise, GCloud SDK, Cloud SQL Proxy)
-       └─ go/   → docker-ubuntu-go   (Go 1.26 toolchain & CLIs via mise, kubebuilder, GPG, PostgreSQL, GCloud SDK)
+       ├─ java/ → docker-ubuntu-java (Java 25 LTS / Maven / Gradle via mise)
+       └─ go/   → docker-ubuntu-go   (Go 1.26 toolchain & CLIs via mise, kubebuilder, GPG, PostgreSQL)
 ```
 
 Each `<context>/` directory holds: a `Dockerfile`, a pinned `.mise.toml`, and a small
@@ -103,13 +103,10 @@ image. The old `install-*.sh` tool-fetch scripts were removed when mise took ove
   `FROM ghcr.io/andriykalashnykov/docker-ubuntu-base:$UBUNTU_VERSION`. The Makefile's
   `build-java`/`build-go` depend on `build-base` to produce that tag locally; otherwise
   they pull the published base from GHCR.
-- **Version pins**: only `UBUNTU_VERSION` (Makefile, passed `--build-arg`), `MISE_VERSION`
-  and `GCLOUD_VERSION` (Dockerfile `ARG`s) live outside mise. Java/Maven/Go and every other
+- **Version pins**: only `UBUNTU_VERSION` (Makefile, passed `--build-arg`) and
+  `MISE_VERSION` (base Dockerfile `ARG`) live outside mise. Java/Maven/Go and every other
   tool version live in the `.mise.toml` files — do NOT add language version vars back to
   the Makefile.
-- **gcloud download resilience**: the gcloud `curl` uses `--retry 3 --retry-delay 5
-  --retry-all-errors --connect-timeout 30` (the ~150 MB tarball can time out under
-  parallel java+go builds).
 - **Reproducible caching**: pinned tools make builds reproducible, so the old `random.org`
   cache-busting `ADD`s were removed; `build-*-inline-cache` targets push a `-cache` tag.
 
@@ -121,7 +118,7 @@ to GHCR** (the go image is local-only — it needs operator secrets). Jobs: `cha
 scan → tag-gated push → cosign keyless signing by digest → SBOM (base)) → `ci-pass` aggregator.
 Push happens on `push`/tag events only (PRs build+scan but don't push/sign).
 `cleanup-runs.yml` prunes old runs via `gh`. Renovate (`renovate.json`) updates the Ubuntu
-tag, Action SHAs, gcloud/mise ARGs, and every mise-pinned tool.
+tag (+ its pinned digest), Action SHAs, the mise ARG, and every mise-pinned tool.
 
 ## Skills
 
@@ -138,8 +135,15 @@ agent's prompt.
 
 ## Improvement Backlog
 
-- **Multi-arch** — images build `linux/amd64` only; add `linux/arm64` for Apple Silicon /
-  Graviton (gcloud + some mise tools need arch-aware asset selection).
+- **Multi-arch (arm64)** — PREPARED but intentionally DISABLED; builds are `linux/amd64`
+  only for now (see the commented scaffold near `build-base` in the Makefile). All
+  asset-level blockers are cleared and a `linux/arm64` base build was confirmed to
+  succeed: gcloud (the one hardcoded `x86_64` asset) and cloud-sql-proxy were removed,
+  the amd64-only `rar` package was swapped for `unrar` (arm64-available; extraction
+  kept, proprietary creation dropped), and every mise-pinned tool has verified arm64
+  builds; `mise.run`, `get.docker.com`, and apt are already arch-aware. To enable later:
+  convert the build to `docker buildx --platform linux/amd64,linux/arm64 --push`
+  (Makefile + CI) with multi-arch cosign/SBOM and a QEMU/native-arm-runner choice.
 - **Publish go from CI** — now *unblocked* (the go image is credential-free; see "Secrets"
   above). Still local-only by policy; enabling CI publish would only require adding go to
   the build/push jobs — no secret-surface decision remains.

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,21 @@ ci: lint build-base
 renovate-validate:
 	@npx --yes --package renovate -- renovate-config-validator
 
+# --- Multi-arch (arm64): PREPARED but DISABLED — builds are amd64-only for now ---
+# The images are arm64-ready: no arch-specific assets remain (gcloud removed,
+# every mise tool has verified arm64 builds, rar→unrar), and a linux/arm64 base
+# build has been confirmed to succeed. To enable arm64 later, build with buildx
+# and push a manifest list (multi-arch images cannot be `docker load`ed locally):
+#
+#   docker buildx build --platform linux/amd64,linux/arm64 \
+#     --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) --build-arg IMAGE_LABEL=$(IMAGE) \
+#     --push -t $(IMAGE_NAME) ./base
+#
+# CI would also need: a QEMU setup or native arm64 runners, and multi-arch-aware
+# cosign signing + SBOM (sign/scan the index digest). Until then: amd64 only.
+# PLATFORMS ?= linux/amd64
+# ---------------------------------------------------------------------------------
+
 #build-base-inline-cache: @ Build remote cache for the base image
 build-base-inline-cache: check-env
 	@docker build --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg IMAGE_LABEL=$(IMAGE) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) --build-arg USER_UID=$(USER_UID) --build-arg USER_GID=$(USER_GID) --build-arg USER_NAME=$(USER_NAME) --build-arg USER_PWD=$(USER_PWD) --build-arg ROOT_PWD=$(ROOT_PWD) -t $(IMAGE_INLINE_CACHE_NAME) ./base

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Renovate-managed GitHub Actions pipeline.
 ```text
 ubuntu:26.04 (LTS)
   └─ docker-ubuntu-base   base + DevOps toolchain (mise-managed) + Docker-in-Docker
-       ├─ docker-ubuntu-java   + Java 25 LTS / Maven / Gradle, Google Cloud SDK, Cloud SQL Proxy
+       ├─ docker-ubuntu-java   + Java 25 LTS / Maven / Gradle
        └─ docker-ubuntu-go     + Go toolchain & dev CLIs, kubebuilder, goreleaser,
-                                 GPG, PostgreSQL, Google Cloud SDK, Cloud SQL Proxy
+                                 GPG, PostgreSQL
 ```
 
 The `java` and `go` images are built `FROM ghcr.io/andriykalashnykov/docker-ubuntu-base`,
@@ -34,8 +34,8 @@ so `make build-java` / `make build-go` depend on `make build-base`.
 
 All CLI tools are managed by **[mise](https://mise.jdx.dev)** and pinned in
 per-image `.mise.toml` files (`base/.mise.toml`, `java/.mise.toml`,
-`go/.mise.toml`); the base OS, mise itself, and the Google Cloud SDK are pinned
-via Dockerfile `ARG`s. Everything is kept current automatically by Renovate.
+`go/.mise.toml`); the base OS (tag + digest) and mise itself are pinned via
+Dockerfile `ARG`s. Everything is kept current automatically by Renovate.
 The full strategy and the list of what is/ isn't mise-managed is documented in
 **[TOOLING.md](./TOOLING.md)**.
 
@@ -153,7 +153,7 @@ Run `make help` for the authoritative list.
   — weekly prune of old workflow runs via the `gh` CLI.
 
 Dependency updates are handled by **Renovate** (`renovate.json`): the Ubuntu base
-tag, GitHub Action SHAs, the gcloud/mise `ARG`s, and every mise-pinned tool.
+tag (+ pinned digest), GitHub Action SHAs, the mise `ARG`, and every mise-pinned tool.
 
 ### Verify a published image signature
 

--- a/TOOLING.md
+++ b/TOOLING.md
@@ -12,12 +12,11 @@ reproducible and dependency bumps are automated. There is one rule:
 |-------|-----------|-----------------|-----------------|
 | CLI dev tools (kubectl, helm, go, java, …) | **[mise](https://mise.jdx.dev)** | `base/.mise.toml`, `java/.mise.toml`, `go/.mise.toml` | Renovate `mise` manager |
 | Go dev CLIs (dlv, swag, goose, …) | mise **`go:` backend** | `go/.mise.toml` | Renovate |
-| Prebuilt single binaries (goreleaser, cloud-sql-proxy, vivid) | mise **`aqua:` backend** | the `.mise.toml` files | Renovate |
+| Prebuilt single binaries (goreleaser, vivid) | mise **`aqua:` backend** | the `.mise.toml` files | Renovate |
 | s2i (not in the aqua registry) | mise **`github:` backend** (`exe = "s2i"`) | `base/.mise.toml` | Renovate |
 | Base OS image | Docker `FROM` + `ARG UBUNTU_VERSION` | `Makefile` (`UBUNTU_VERSION`) + Dockerfile `ARG` | Renovate (`# renovate:` custom manager) |
 | mise itself | pinned installer | `base/Dockerfile` (`ARG MISE_VERSION`) | Renovate (`# renovate:`) |
 | OS packages (git, gnupg, postgresql, docker-engine…) | `apt-get` | the Dockerfiles | — (tracks the Ubuntu release) |
-| Google Cloud SDK | pinned official tarball | java/go Dockerfiles (`ARG GCLOUD_VERSION`) | Renovate (`# renovate:`) |
 
 ## Why mise for "everything possible"
 
@@ -36,10 +35,6 @@ files for the authoritative list.
 |------|-----------------------|-----------------------|
 | `git`, `gnupg`, `postgresql`, build tools | OS packages — belong to apt, not a version manager | Tracks the pinned Ubuntu release |
 | Docker engine (Docker-in-Docker) | Installed via the official `get.docker.com` convenience script in the base image | Tied to the Docker channel; bump by re-building |
-| **Google Cloud SDK** | A multi-component SDK (hundreds of files, component manager), not a single versioned binary — mise has no first-class backend | `ARG GCLOUD_VERSION` pinned to the official versioned tarball + `# renovate:` comment |
-
-`cloud-sql-proxy` **is** a single binary, so it lives under mise (`aqua:`) even
-though the gcloud SDK does not.
 
 ## The image layering & mise config merge
 
@@ -47,8 +42,8 @@ though the gcloud SDK does not.
 base/.mise.toml  → installed as the mise GLOBAL config (~/.config/mise/config.toml)
                    k8s + devops toolset every image inherits
    │
-   ├─ java/.mise.toml → ~/.mise.toml (LOCAL, merges on top) → + java/maven/gradle + cloud-sql-proxy
-   └─ go/.mise.toml   → ~/.mise.toml (LOCAL, merges on top) → + go + go CLIs + kubebuilder + goreleaser + cloud-sql-proxy
+   ├─ java/.mise.toml → ~/.mise.toml (LOCAL, merges on top) → + java/maven/gradle
+   └─ go/.mise.toml   → ~/.mise.toml (LOCAL, merges on top) → + go + go CLIs + kubebuilder + goreleaser
 ```
 
 At container start, `scripts/entry.sh` runs `mise activate`, so every pinned
@@ -57,7 +52,7 @@ tool is on `PATH` with its environment (`JAVA_HOME`, `GOROOT`, …) set.
 ## How to add or bump a tool
 
 1. **Bump a version** — edit the version string in the relevant `.mise.toml`
-   (or the `ARG` for gcloud/ubuntu/mise). Renovate will also open PRs for these
+   (or the `ARG` for ubuntu/mise). Renovate will also open PRs for these
    automatically.
 2. **Add a new tool** — confirm a backend exists: `mise registry | grep <name>`
    (or use an explicit `aqua:owner/repo` / `go:module` ref). Add the pinned

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -50,7 +50,7 @@ RUN (userdel -r ubuntu 2>/dev/null || true) \
 # so psql is preserved; it is a Depends, not a Recommends).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https ca-certificates apt-utils software-properties-common curl wget lsb-release sudo locales xclip xsel bash-completion \
-    vim nano zip unzip rar openssl ssh openssh-client tree git gitg git-lfs graphviz \
+    vim nano zip unzip unrar openssl ssh openssh-client tree git gitg git-lfs graphviz \
     gnupg gnupg2 net-tools jq httpie htop nmon iputils-ping html-xml-utils libxml2-utils xmlstarlet libnss3-tools slirp4netns \
     xdotool buildah podman skopeo postgresql-client make gcc python3-dev python3-pip python3-crcmod \
     && apt-get autoremove -y \

--- a/go/.mise.toml
+++ b/go/.mise.toml
@@ -9,8 +9,7 @@ go          = "1.26.3"        # current stable (was 1.18.2, EOL)
 kubebuilder = "4.14.0"
 
 # Prebuilt binaries via aqua (fast, no compile).
-"aqua:GoogleCloudPlatform/cloud-sql-proxy" = "2.22.0"
-"aqua:goreleaser/goreleaser"               = "2.16.0"
+"aqua:goreleaser/goreleaser" = "2.16.0"
 
 # Go dev CLIs via the mise `go:` backend — pinned, reproducible (vs `go install @latest`).
 # Dropped from the old toolchain script as obsolete/removed-from-upstream:

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -13,11 +13,6 @@ ARG USER_PWD="user"
 ARG USER_EMAIL="user@test.com"
 ARG IMAGE_LABEL="docker-ubuntu-go"
 
-# Google Cloud SDK — official versioned installer (multi-component SDK, not a
-# single mise-managed binary). Pinned for reproducibility.
-# renovate: datasource=docker depName=google/cloud-sdk
-ARG GCLOUD_VERSION="570.0.0"
-
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=xterm
 ENV TZ=America/New_York
@@ -51,17 +46,10 @@ RUN git lfs install \
     && chmod 644 /home/$USER_NAME/.ssh/config /home/$USER_NAME/.ssh/known_hosts \
     && echo -e "\nexport TERM=$TERM" >> /home/$USER_NAME/.bashrc
 
-# Go toolchain + Go dev CLIs + kubebuilder + goreleaser + cloud-sql-proxy via mise.
+# Go toolchain + Go dev CLIs + kubebuilder + goreleaser via mise.
 # Merges on top of the base image's global mise config (full base toolset inherited).
 COPY --chown=$USER_UID:$USER_GID .mise.toml /home/$USER_NAME/.mise.toml
 RUN mise trust /home/$USER_NAME/.mise.toml && mise install --yes && mise reshim
-
-# Google Cloud SDK — pinned official installer.
-RUN curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" -o /tmp/gcloud.tgz \
-    && sudo tar -xzf /tmp/gcloud.tgz -C /opt \
-    && sudo /opt/google-cloud-sdk/install.sh --quiet --path-update false \
-    && rm -f /tmp/gcloud.tgz
-ENV PATH="/opt/google-cloud-sdk/bin:$PATH"
 
 CMD ["/bin/bash"]
 ENTRYPOINT bash -c "source $HOME/scripts/entry.sh && $0 $@"

--- a/java/.mise.toml
+++ b/java/.mise.toml
@@ -7,6 +7,3 @@
 java   = "temurin-25.0.3+9.0.LTS"   # current LTS (was SDKMAN 18.0.1-tem, EOL)
 maven  = "3.9.16"
 gradle = "9.5.1"
-
-# Cloud SQL Proxy (single binary; gcloud SDK itself stays on its official installer).
-"aqua:GoogleCloudPlatform/cloud-sql-proxy" = "2.22.0"

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -11,11 +11,6 @@ ARG USER_NAME="user"
 ARG USER_EMAIL="user@test.com"
 ARG IMAGE_LABEL="docker-ubuntu-java"
 
-# Google Cloud SDK — official versioned installer (multi-component SDK, not a
-# single mise-managed binary). Pinned for reproducibility.
-# renovate: datasource=docker depName=google/cloud-sdk
-ARG GCLOUD_VERSION="570.0.0"
-
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=xterm
 ENV TZ=America/New_York
@@ -38,17 +33,10 @@ RUN git config --global user.name $USER_NAME \
     && chmod 700 /home/$USER_NAME/.ssh \
     && chmod 644 /home/$USER_NAME/.ssh/config /home/$USER_NAME/.ssh/known_hosts
 
-# JVM stack (java/maven/gradle) + cloud-sql-proxy via mise — replaces SDKMAN.
+# JVM stack (java/maven/gradle) via mise — replaces SDKMAN.
 # Merges on top of the base image's global mise config (full base toolset inherited).
 COPY --chown=$USER_UID:$USER_GID .mise.toml /home/$USER_NAME/.mise.toml
 RUN mise trust /home/$USER_NAME/.mise.toml && mise install --yes && mise reshim
-
-# Google Cloud SDK — pinned official installer.
-RUN curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" -o /tmp/gcloud.tgz \
-    && sudo tar -xzf /tmp/gcloud.tgz -C /opt \
-    && sudo /opt/google-cloud-sdk/install.sh --quiet --path-update false \
-    && rm -f /tmp/gcloud.tgz
-ENV PATH="/opt/google-cloud-sdk/bin:$PATH"
 
 CMD ["/bin/bash"]
 ENTRYPOINT bash -c "source $HOME/scripts/entry.sh && $0 $@"


### PR DESCRIPTION
Strips the Google Cloud tooling and the one arch-specific apt package so the images carry **no amd64-only assets** — making future `linux/arm64` a trivial flip. Builds stay **amd64-only for now**; arm64 is left as a commented-out, ready-to-enable scaffold.

## Removed — gcloud SDK
The one hardcoded `linux-x86_64` download and the heaviest layer (~150MB+).
- `java/Dockerfile` + `go/Dockerfile`: dropped `ARG GCLOUD_VERSION` (+ `# renovate`), the `curl | tar | install.sh` RUN, and the PATH entry.
- `main.yml`: dropped the 2 Trivy `skip-dirs` gsutil hacks (only needed because the SDK bundled vulnerable third-party gsutil deps).
- Loses `gcloud`/`gsutil`/`bq`.

## Removed — Cloud SQL Proxy
- `java/.mise.toml` + `go/.mise.toml`: dropped the `aqua:GoogleCloudPlatform/cloud-sql-proxy` pin.

## arm64-readiness
- `base/Dockerfile`: **`rar` → `unrar`**. The proprietary `rar` package is amd64/i386-only (no arm64 candidate) and was the *sole* apt blocker; `unrar` (arm64-available) keeps `.rar` **extraction**, drops proprietary creation. **Verified by building base for `linux/arm64` via buildx/QEMU (rc=0)** — the full mise toolchain installs on arm64.
- `Makefile`: added a commented-out multi-arch scaffold near `build-base` documenting how to enable `docker buildx --platform linux/amd64,linux/arm64` later (with the CI cosign/SBOM + runner notes).

## Docs
`CLAUDE.md` / `README.md` / `TOOLING.md`: removed all gcloud + cloud-sql-proxy mentions; updated the multi-arch backlog note (asset blockers cleared, arm64 confirmed-buildable, amd64-only for now).

### Verification
- amd64 base/java/go build (rc=0); `unrar` present & `rar`/`gcloud`/`cloud-sql-proxy` absent in the amd64 image.
- arm64 base build (rc=0, `Arch: arm64`) — the readiness proof.
- hadolint (all 3) + `make lint` + `renovate-validate` clean.

Context: ran as `/ship-it` — Stage 1 (upgrade) found nothing new (Renovate current); Stage 2 review of the changeset was clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)