### PR TITLE
docs: refresh CLAUDE.md + README (/claude + /readme post-removal accuracy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ is load-bearing for cleanup, not cosmetic. The registry is forced to `ghcr.io` w
 ## Tool / version management (read TOOLING.md)
 
 **mise is the single tool-version manager.** Every CLI tool is pinned in a per-image
-`.mise.toml` (`base/.mise.toml`, `java/.mise.toml`, `go/.mise.toml`); the base OS tag,
-mise itself, and the Google Cloud SDK are pinned via Dockerfile/Makefile `ARG`s/vars with
+`.mise.toml` (`base/.mise.toml`, `java/.mise.toml`, `go/.mise.toml`); the base OS tag
+(+ pinned digest) and mise itself are pinned via Dockerfile/Makefile `ARG`s/vars with
 `# renovate:` annotations. **[TOOLING.md](./TOOLING.md)** is the authoritative strategy doc.
 Key rules:
 
@@ -137,18 +137,22 @@ agent's prompt.
 
 - **Multi-arch (arm64)** — PREPARED but intentionally DISABLED; builds are `linux/amd64`
   only for now (see the commented scaffold near `build-base` in the Makefile). All
-  asset-level blockers are cleared and a `linux/arm64` base build was confirmed to
-  succeed: gcloud (the one hardcoded `x86_64` asset) and cloud-sql-proxy were removed,
-  the amd64-only `rar` package was swapped for `unrar` (arm64-available; extraction
-  kept, proprietary creation dropped), and every mise-pinned tool has verified arm64
-  builds; `mise.run`, `get.docker.com`, and apt are already arch-aware. To enable later:
-  convert the build to `docker buildx --platform linux/amd64,linux/arm64 --push`
-  (Makefile + CI) with multi-arch cosign/SBOM and a QEMU/native-arm-runner choice.
+  asset-level blockers are cleared and a `linux/arm64` **base** build was confirmed to
+  succeed (the hard part: full apt list + entire mise toolchain): gcloud (the one
+  hardcoded `x86_64` asset) and cloud-sql-proxy were removed, the amd64-only `rar` package
+  was swapped for `unrar` (arm64-available; extraction kept, proprietary creation dropped),
+  and every mise-pinned tool has verified arm64 builds; `mise.run`, `get.docker.com`, and
+  apt are already arch-aware. java/go add only arch-clean layers but are not individually
+  arm64-proven. To enable later: convert the build to `docker buildx --platform
+  linux/amd64,linux/arm64 --push` (Makefile + CI) with multi-arch cosign/SBOM and a
+  QEMU/native-arm-runner choice.
 - **Publish go from CI** — now *unblocked* (the go image is credential-free; see "Secrets"
   above). Still local-only by policy; enabling CI publish would only require adding go to
   the build/push jobs — no secret-surface decision remains.
-
-### Resolved
-- **go image credential surface** — RESOLVED. Operator SSH/GPG/PAT are injected at
-  container start (`go/scripts/entry.sh` from `make run-go` runtime mounts/env), never
-  baked into the image filesystem.
+- **java image SBOM** — `main.yml` generates `sbom-base.spdx.json` for the base image only;
+  the **java** image is published + cosign-signed identically but gets **no SBOM**. Close
+  the asymmetry by mirroring the `Generate SBOM (base)` step for the java image ref. This
+  is an image-hardening change — apply via `/ship-it harden`, not the default pipeline.
+- **go shell-form `ENTRYPOINT`** (`bash -c "… $0 $@"`, DL3025-ignored) mangles complex
+  multi-word `docker run … <cmd>` invocations; `make run-go` (bare `bash`) is unaffected.
+  Latent ergonomics wart, not a bug.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The full strategy and the list of what is/ isn't mise-managed is documented in
 
 **All three images build with no host secrets** — the filesystem is credential-free.
 For the **go** image, the operator's credentials are injected **at container start**
-by `make run-go` (never baked into the image): the SSH key pair at
-`~/.ssh/id_rsa{,.pub}`, the GPG key pair at
+by `make run-go` (never baked into the image): an SSH key pair at
+`~/.ssh/id_rsa{,.pub}` or `~/.ssh/id_ed25519{,.pub}`, the GPG key pair at
 `${DOTFILES_DIR}/gnupg/AndriyKalashnykov-secret-gpg.key` + `…-ownertrust-gpg.txt`
 (`DOTFILES_DIR` defaults to `~/projects/dotfiles`), and the `GITHUB_PAT` /
 `MY_GPG_PASSWORD` env vars — each used only if present (otherwise a fresh SSH key is
@@ -72,7 +72,8 @@ make build-go   && make run-go        # go dev image
 
 `run-*` drops you into an interactive `bash` shell with the full toolchain on
 `PATH` (and `JAVA_HOME` / `GOROOT` set by the entrypoint). `run-go` additionally
-bind-mounts the host Docker socket (Docker-out-of-Docker) and the current directory.
+bind-mounts the host Docker socket (Docker-out-of-Docker) and the current directory,
+and injects your SSH/GPG keys + PAT at container start (if present on the host).
 
 ### Run a published image (no build needed)
 
@@ -107,8 +108,9 @@ docker run --rm -it -v "$PWD":/home/user/app -w /home/user/app \
   ghcr.io/andriykalashnykov/docker-ubuntu-java:26.04 bash
 ```
 
-> The **go** image is built locally only (`make build-go`) — it is not published
-> to GHCR because it can carry operator credentials, so build it before running it.
+> The **go** image is built locally only (`make build-go`) — a personal dev container
+> that is local-only by policy (the image itself is credential-free; SSH/GPG/PAT are
+> injected at run time), so build it before running it.
 
 ## Make targets
 


### PR DESCRIPTION
Self-review-bias-guard pass after this session's gcloud/cloud-sql-proxy removal and the go credential-injection change. CLAUDE.md and README.md aren't in the CI paths-filter, so the build job skips (ci-pass passes on skipped).

## CLAUDE.md (`/claude`)
- Fix stale **"the Google Cloud SDK are pinned via Dockerfile ARGs"** — gcloud was removed; only `UBUNTU_VERSION` (+ digest) and `MISE_VERSION` live outside mise now.
- Backlog: re-add the **java image SBOM** item + a note on the go shell-form `ENTRYPOINT` quoting; fold the arm64-proof-covers-base-only caveat into the multi-arch item; prune the "Resolved" memorial (backlog hygiene).
- Skills section verified present + accurate.

## README.md (`/readme`)
- Fix stale go-image blockquote: local-only **by policy** + **credential-free** (creds injected at run time).
- Note `id_ed25519` support + that `run-go` injects creds.
- Scannability suite clean.

## `/repo-about`
Current About kept as-is (user confirmed "keep A").

🤖 Generated with [Claude Code](https://claude.com/claude-code)