### PR TITLE
chore: scope renovate enabledManagers (drop redundant/circular dockerfile tracking)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:best-practices",
     ":semanticCommitType(chore)"
   ],
+  "enabledManagers": ["mise", "github-actions", "custom.regex"],
   "labels": ["dependencies"],
   "commitMessagePrefix": "chore(all): ",
   "commitMessageAction": "update",


### PR DESCRIPTION
`/renovate` review via a live `--dry-run=lookup`.

**Finding (MEDIUM):** the default `dockerfile` manager extracted 4 deps from the 3 Dockerfiles:
- `ubuntu` (base `FROM`) — **redundant**: the customManager already owns the tag + the seeded `UBUNTU_DIGEST`.
- `docker-ubuntu-base` ×2 (java/go `FROM`) — **circular**: the internal base image, which Renovate would try to bump against itself.
- `docker/dockerfile` (go `# syntax=` directive, `:1` — never bumps within major 1).

**Fix:** `enabledManagers: [mise, github-actions, custom.regex]`. Dry-run confirms: total deps 58→54 (exactly those 4 removed); `mise` (29, incl. s2i), `github-actions` (19), and `custom.regex` (6 — ubuntu tag+digest + MISE_VERSION) all still tracked. Schema validates.

Everything else in `renovate.json` was already conformant (config:best-practices, automerge stack, vuln fast-track, major buffer, the UBUNTU_DIGEST customManager, s2i version_prefix — all landed earlier this session). renovate.json isn't in the CI paths-filter, so the build job skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)