### PR TITLE
chore: add 3-day minimumReleaseAge to mise tools (tag-before-publish race)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,9 +27,10 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Group mise tool bumps per image",
+      "description": "Group mise tool bumps per image; hold each new version for a 3-day stability buffer so upstream GitHub Release artifacts (which mise's aqua:/github-tags backend installs) are published before the PR opens — prevents the tag-before-publish 404 (PR #96: k9s 0.50.18->0.51.0 404'd because CI ran in the ~9h window between the v0.51.0 tag and its Release publish).",
       "matchManagers": ["mise"],
-      "groupName": "mise tools"
+      "groupName": "mise tools",
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Hold major updates for a 3-day stability buffer before opening a PR",


### PR DESCRIPTION
## Root cause (fixes the class behind PR #96's failure)

PR #96 (`k9s 0.50.18 → 0.51.0`) failed in the `build` job:

```
mise ERROR Failed to install aqua:derailed/k9s@0.51.0: 404 Not Found (releases/tags/v0.51.0)
```

**Tag-published-before-release-artifacts race.** Timeline (2026-06-06 UTC):

| Event | Time |
|---|---|
| k9s `v0.51.0` git tag created | 05:22:55 |
| Renovate opened PR #96 (saw tag via `github-tags` datasource) | 09:55:40 |
| CI `build` ran → mise install 404 | 09:55:43 |
| k9s `v0.51.0` GitHub **Release published** | 14:13:12 |

mise's `aqua:derailed/k9s` backend installs from the GitHub *Release*, which was a **draft** (→ 404) for the ~9h after the tag. The bump is valid — it installs cleanly now that the release is published.

## Fix

`renovate.json` applied `minimumReleaseAge` to **major updates only**. This race also bites minor/patch bumps (k9s is a minor bump). Fold a manager-wide **3-day** buffer into the `mise tools` group rule so every tool waits for upstream artifacts to publish before the PR opens — a durable, allowlist-free fix.

## Test plan
- [x] `make renovate-validate` passes (config validated against schema)
- [x] `mise install k9s@0.51.0` spiked locally in isolated `MISE_DATA_DIR` → installs cleanly (release now published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)