### PR TITLE
chore: standardize env var names, portable GPG vars, fix Renovate pin branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ bind-mounts / env supplied by `make run-go` — they never enter the image files
 | Credential | Runtime source (mounted/passed by `make run-go`) | In-container target | Absent → |
 |-----------|--------|--------|----------|
 | SSH key | `~/.ssh/id_rsa{,.pub}` → `/run/host-ssh/` (ro bind) | `~/.ssh/id_rsa{,.pub}` + `authorized_keys` | a fresh per-container key is generated |
-| GPG key | `${DOTFILES_DIR}/gnupg/AndriyKalashnykov-*.{key,txt}` → `/run/host-gpg/` (ro bind) | imported into `~/.gnupg` | GPG import skipped |
+| GPG key | `$GPG_SECRET_KEY_FILE` + `$GPG_OWNERTRUST_FILE` → `/run/host-gpg/` (ro bind) | imported into `~/.gnupg` | GPG import skipped |
 | GPG passphrase | `$GPG_PASSPHRASE` (`-e`, value from env) | used for the import | GPG import skipped |
 | GitHub PAT | `$GITHUB_PAT` (`-e`, value from env) | `~/.netrc` (0600) | `.netrc` not written |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ make cleanup          # Remove all images/layers/exited containers/dangling vols
 validation of an image is "does it build"). `make delete-*` / `make cleanup` find images
 by the `LABEL stage=<IMAGE_LABEL>` set in each Dockerfile, so the build-arg `IMAGE_LABEL`
 is load-bearing for cleanup, not cosmetic. The registry is forced to `ghcr.io` with `:=`
-(env-pollution-proof); override per-invocation with `make DOCKER_REGISTRY=...`.
+(env-pollution-proof); override per-invocation with `make IMAGE_REGISTRY=...`.
 
 ## Tool / version management (read TOOLING.md)
 
@@ -67,7 +67,7 @@ bind-mounts / env supplied by `make run-go` — they never enter the image files
 |-----------|--------|--------|----------|
 | SSH key | `~/.ssh/id_rsa{,.pub}` → `/run/host-ssh/` (ro bind) | `~/.ssh/id_rsa{,.pub}` + `authorized_keys` | a fresh per-container key is generated |
 | GPG key | `${DOTFILES_DIR}/gnupg/AndriyKalashnykov-*.{key,txt}` → `/run/host-gpg/` (ro bind) | imported into `~/.gnupg` | GPG import skipped |
-| GPG passphrase | `$MY_GPG_PASSWORD` (`-e`, value from env) | used for the import | GPG import skipped |
+| GPG passphrase | `$GPG_PASSPHRASE` (`-e`, value from env) | used for the import | GPG import skipped |
 | GitHub PAT | `$GITHUB_PAT` (`-e`, value from env) | `~/.netrc` (0600) | `.netrc` not written |
 
 The Makefile builds the `GO_RUN_CREDS` mount/env list conditionally (`$(wildcard ...)` +

--- a/Makefile
+++ b/Makefile
@@ -19,20 +19,20 @@ USER_EMAIL ?= AndriyKalashnykov@gmail.com
 
 # Registry — GitHub Container Registry. Auth uses a GitHub PAT (GITHUB_PAT) with
 # write:packages. REGISTRY_OWNER MUST be lowercase (ghcr requirement).
-# `:=` (not `?=`) so an exported DOCKER_REGISTRY in the shell can't silently
-# redirect publishes; override on the command line with `make DOCKER_REGISTRY=...`.
-DOCKER_REGISTRY := ghcr.io
+# `:=` (not `?=`) so an exported IMAGE_REGISTRY in the shell can't silently
+# redirect publishes; override on the command line with `make IMAGE_REGISTRY=...`.
+IMAGE_REGISTRY := ghcr.io
 REGISTRY_OWNER  := andriykalashnykov
 
 IMAGE      := docker-ubuntu-base
 IMAGE_JAVA := docker-ubuntu-java
 IMAGE_GO   := docker-ubuntu-go
 
-IMAGE_NAME                   := $(DOCKER_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE):$(UBUNTU_VERSION)
-IMAGE_INLINE_CACHE_NAME      := $(DOCKER_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE)-cache:$(UBUNTU_VERSION)
-IMAGE_JAVA_NAME              := $(DOCKER_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE_JAVA):$(UBUNTU_VERSION)
-IMAGE_JAVA_INLINE_CACHE_NAME := $(DOCKER_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE_JAVA)-cache:$(UBUNTU_VERSION)
-IMAGE_GO_NAME                := $(DOCKER_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE_GO):$(UBUNTU_VERSION)
+IMAGE_NAME                   := $(IMAGE_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE):$(UBUNTU_VERSION)
+IMAGE_INLINE_CACHE_NAME      := $(IMAGE_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE)-cache:$(UBUNTU_VERSION)
+IMAGE_JAVA_NAME              := $(IMAGE_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE_JAVA):$(UBUNTU_VERSION)
+IMAGE_JAVA_INLINE_CACHE_NAME := $(IMAGE_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE_JAVA)-cache:$(UBUNTU_VERSION)
+IMAGE_GO_NAME                := $(IMAGE_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE_GO):$(UBUNTU_VERSION)
 
 export DOCKER_BUILDKIT=1
 
@@ -69,8 +69,8 @@ endif
 ifneq ($(strip $(GITHUB_PAT)),)
 GO_RUN_CREDS += -e GITHUB_PAT
 endif
-ifneq ($(strip $(MY_GPG_PASSWORD)),)
-GO_RUN_CREDS += -e MY_GPG_PASSWORD
+ifneq ($(strip $(GPG_PASSPHRASE)),)
+GO_RUN_CREDS += -e GPG_PASSPHRASE
 endif
 
 # make sure docker is installed
@@ -96,8 +96,8 @@ check-env:
 
 #login: @ Log in to GHCR (uses GITHUB_PAT with write:packages)
 login: check-env
-	@[ -n "$$GITHUB_PAT" ] || { echo "ERROR: GITHUB_PAT (write:packages) is required to log in to $(DOCKER_REGISTRY)"; exit 1; }
-	@printf '%s' "$$GITHUB_PAT" | docker login $(DOCKER_REGISTRY) -u $(REGISTRY_OWNER) --password-stdin
+	@[ -n "$$GITHUB_PAT" ] || { echo "ERROR: GITHUB_PAT (write:packages) is required to log in to $(IMAGE_REGISTRY)"; exit 1; }
+	@printf '%s' "$$GITHUB_PAT" | docker login $(IMAGE_REGISTRY) -u $(REGISTRY_OWNER) --password-stdin
 
 #lint: @ Lint Dockerfiles (hadolint) + verify shell scripts are executable
 lint: lint-scripts-exec

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,13 @@ IMAGE_GO_NAME                := $(IMAGE_REGISTRY)/$(REGISTRY_OWNER)/$(IMAGE_GO):
 
 export DOCKER_BUILDKIT=1
 
-DOTFILES_DIR ?= $(HOME)/projects/dotfiles
+# GPG key files injected into the go image at run time (optional, for signed git).
+# Point these at YOUR exported secret key + ownertrust — any name, any path:
+#   gpg --export-secret-keys --armor KEYID > secret.key
+#   gpg --export-ownertrust                > ownertrust.txt
+# Defaults are the owner's dotfiles layout; override per-invocation or via env.
+GPG_SECRET_KEY_FILE ?= $(HOME)/projects/dotfiles/gnupg/AndriyKalashnykov-secret-gpg.key
+GPG_OWNERTRUST_FILE ?= $(HOME)/projects/dotfiles/gnupg/AndriyKalashnykov-ownertrust-gpg.txt
 
 # Runtime credential injection for the go image (`make run-go`). The image bakes
 # NO secrets — the operator's SSH/GPG keys and PAT are mounted/passed at CONTAINER
@@ -60,11 +66,11 @@ endif
 ifneq ($(wildcard $(HOME)/.ssh/id_ed25519.pub),)
 GO_RUN_CREDS += -v $(HOME)/.ssh/id_ed25519.pub:/run/host-ssh/id_ed25519.pub:ro
 endif
-ifneq ($(wildcard $(DOTFILES_DIR)/gnupg/AndriyKalashnykov-secret-gpg.key),)
-GO_RUN_CREDS += -v $(DOTFILES_DIR)/gnupg/AndriyKalashnykov-secret-gpg.key:/run/host-gpg/secret.key:ro
+ifneq ($(wildcard $(GPG_SECRET_KEY_FILE)),)
+GO_RUN_CREDS += -v $(GPG_SECRET_KEY_FILE):/run/host-gpg/secret.key:ro
 endif
-ifneq ($(wildcard $(DOTFILES_DIR)/gnupg/AndriyKalashnykov-ownertrust-gpg.txt),)
-GO_RUN_CREDS += -v $(DOTFILES_DIR)/gnupg/AndriyKalashnykov-ownertrust-gpg.txt:/run/host-gpg/ownertrust.txt:ro
+ifneq ($(wildcard $(GPG_OWNERTRUST_FILE)),)
+GO_RUN_CREDS += -v $(GPG_OWNERTRUST_FILE):/run/host-gpg/ownertrust.txt:ro
 endif
 ifneq ($(strip $(GITHUB_PAT)),)
 GO_RUN_CREDS += -e GITHUB_PAT

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ The full strategy and the list of what is/ isn't mise-managed is documented in
 **All three images build with no host secrets** — the filesystem is credential-free.
 For the **go** image, the operator's credentials are injected **at container start**
 by `make run-go` (never baked into the image): an SSH key pair at
-`~/.ssh/id_rsa{,.pub}` or `~/.ssh/id_ed25519{,.pub}`, the GPG key pair at
-`${DOTFILES_DIR}/gnupg/AndriyKalashnykov-secret-gpg.key` + `…-ownertrust-gpg.txt`
-(`DOTFILES_DIR` defaults to `~/projects/dotfiles`), and the `GITHUB_PAT` /
+`~/.ssh/id_rsa{,.pub}` or `~/.ssh/id_ed25519{,.pub}`, a GPG secret key + ownertrust
+at `$GPG_SECRET_KEY_FILE` / `$GPG_OWNERTRUST_FILE`, and the `GITHUB_PAT` /
 `GPG_PASSPHRASE` env vars — each used only if present (otherwise a fresh SSH key is
-generated and GPG/PAT setup is skipped). These paths are owner-specific.
+generated and GPG/PAT setup is skipped). The `GPG_*` defaults point at the owner's
+dotfiles; set them to your own exported files (see the example below).
 
 ```bash
 export GITHUB_PAT=<github-pat-with-write:packages>   # for `make login` / push to GHCR
@@ -120,10 +120,13 @@ need; each is optional and used only if present:
 #   Passed by env NAME only (the value never appears in argv).
 export GITHUB_PAT=<github-pat-with-write:packages>
 
-# GPG signing key — key pair read from $DOTFILES_DIR/gnupg/ (default ~/projects/dotfiles);
-#   passphrase passed by env NAME only.
+# GPG signing key — point these at YOUR exported secret key + ownertrust files
+#   (read-only bind-mounts); the passphrase is passed by env NAME only.
+gpg --export-secret-keys --armor KEYID > ~/gpg-secret.key
+gpg --export-ownertrust                > ~/gpg-ownertrust.txt
+export GPG_SECRET_KEY_FILE=~/gpg-secret.key
+export GPG_OWNERTRUST_FILE=~/gpg-ownertrust.txt
 export GPG_PASSPHRASE=<your-gpg-key-passphrase>
-export DOTFILES_DIR=~/projects/dotfiles      # override if your dotfiles live elsewhere
 
 make build-go && make run-go                 # build (credential-free), then run with creds injected
 ```
@@ -200,7 +203,8 @@ Run `make help` for the authoritative list.
 |----------|---------|
 | `GITHUB_PAT` | GHCR auth (write:packages) for `login`/`push-*`; also injected into the **go** image `.netrc` at run time |
 | `GPG_PASSPHRASE` | GPG key passphrase for the **go** image (passed to `make run-go` at run time) |
-| `DOTFILES_DIR` | Override the dotfiles path (default `~/projects/dotfiles`) |
+| `GPG_SECRET_KEY_FILE` | Path to your exported GPG **secret key** for the **go** image (`gpg --export-secret-keys`); default is the owner's dotfiles file |
+| `GPG_OWNERTRUST_FILE` | Path to your exported GPG **ownertrust** for the **go** image (`gpg --export-ownertrust`); default is the owner's dotfiles file |
 | `IMAGE_REGISTRY` | Override the publish registry (default `ghcr.io`) |
 
 ## CI/CD

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ by `make run-go` (never baked into the image): an SSH key pair at
 `~/.ssh/id_rsa{,.pub}` or `~/.ssh/id_ed25519{,.pub}`, the GPG key pair at
 `${DOTFILES_DIR}/gnupg/AndriyKalashnykov-secret-gpg.key` + `…-ownertrust-gpg.txt`
 (`DOTFILES_DIR` defaults to `~/projects/dotfiles`), and the `GITHUB_PAT` /
-`MY_GPG_PASSWORD` env vars — each used only if present (otherwise a fresh SSH key is
+`GPG_PASSPHRASE` env vars — each used only if present (otherwise a fresh SSH key is
 generated and GPG/PAT setup is skipped). These paths are owner-specific.
 
 ```bash
@@ -104,6 +104,37 @@ make build-go   && make run-go        # go dev image
 `PATH` (and `JAVA_HOME` / `GOROOT` set by the entrypoint). `run-go` additionally
 bind-mounts the host Docker socket (Docker-out-of-Docker) and the current directory,
 and injects your SSH/GPG keys + PAT at container start (if present on the host).
+
+### Go dev container with your SSH / GPG / GitHub credentials
+
+The **go** image is credential-free; `make run-go` injects your credentials **at
+container start** via read-only bind-mounts and env-by-name — no secret value ever
+touches `docker`'s argv, and nothing is baked into the image. Provide whichever you
+need; each is optional and used only if present:
+
+```bash
+# SSH key — auto-detected from ~/.ssh/id_rsa{,.pub} or ~/.ssh/id_ed25519{,.pub}
+#   (read-only bind-mount; if absent, a fresh per-container key is generated)
+
+# GitHub PAT — written to ~/.netrc inside the container for git-over-HTTPS auth.
+#   Passed by env NAME only (the value never appears in argv).
+export GITHUB_PAT=<github-pat-with-write:packages>
+
+# GPG signing key — key pair read from $DOTFILES_DIR/gnupg/ (default ~/projects/dotfiles);
+#   passphrase passed by env NAME only.
+export GPG_PASSPHRASE=<your-gpg-key-passphrase>
+export DOTFILES_DIR=~/projects/dotfiles      # override if your dotfiles live elsewhere
+
+make build-go && make run-go                 # build (credential-free), then run with creds injected
+```
+
+Inside the container your SSH key is at `~/.ssh/`, your PAT is in `~/.netrc` (mode
+`0600`), and your GPG key is imported into `~/.gnupg` — ready for `git clone` over
+HTTPS and signed `git commit -S`.
+
+> **Never** pass these as `docker build --build-arg` / values on the command line —
+> that bakes the secret into the image history and exposes it via `ps` / `docker history`.
+> The runtime-injection flow above is the only supported path.
 
 ### Run a published image (no build needed)
 
@@ -168,9 +199,9 @@ Run `make help` for the authoritative list.
 | Variable | Purpose |
 |----------|---------|
 | `GITHUB_PAT` | GHCR auth (write:packages) for `login`/`push-*`; also injected into the **go** image `.netrc` at run time |
-| `MY_GPG_PASSWORD` | GPG key passphrase for the **go** image (passed to `make run-go` at run time) |
+| `GPG_PASSPHRASE` | GPG key passphrase for the **go** image (passed to `make run-go` at run time) |
 | `DOTFILES_DIR` | Override the dotfiles path (default `~/projects/dotfiles`) |
-| `DOCKER_REGISTRY` | Override the publish registry (default `ghcr.io`) |
+| `IMAGE_REGISTRY` | Override the publish registry (default `ghcr.io`) |
 
 ## CI/CD
 

--- a/go/build.sh
+++ b/go/build.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-DOCKER_BUILDKIT=0 docker build --build-arg USER_EMAIL="AndriyKalashnykov@gmail.com" --build-arg UBUNTU_VERSION="21.10" --build-arg GITHUB_PAT="${GITHUB_PAT}" --build-arg SSH_PUBLIC_KEY="$(cat /home/$USER/.ssh/id_rsa.pub)" --build-arg SSH_PRIVATE_KEY="$(cat /home/$USER/.ssh/id_rsa)" --build-arg GPG_SECRET="$(cat /home/andriy/projects/dotfiles/gnupg/AndriyKalashnykov-secret-gpg.key | base64 -w 0)" --build-arg GPG_OWNER_TRUST="$(cat /home/andriy/projects/dotfiles/gnupg/AndriyKalashnykov-ownertrust-gpg.txt | base64 -w 0)" --build-arg GPG_PWD="${MY_GPG_PASSWORD}" -t go-dev .
-
-# ./scripts/generate-keys.sh "user" "AndriyKalashnykov@gmail.com" "$(cat /home/$USER/.ssh/id_rsa.pub)" "$(cat /home/$USER/.ssh/id_rsa)"
-# ./scripts/generate-gpg-keys.sh "user" "$(cat /home/andriy/projects/dotfiles/gnupg/AndriyKalashnykov-secret-gpg.key | base64 -w 0)" "$(cat /home/andriy/projects/dotfiles/gnupg/AndriyKalashnykov-ownertrust-gpg.txt | base64 -w 0)" "${MY_SSH_PASSWORD}"

--- a/go/scripts/generate-gpg-keys.sh
+++ b/go/scripts/generate-gpg-keys.sh
@@ -2,20 +2,20 @@
 #
 # Runtime GPG import — called by scripts/entry.sh at CONTAINER START (not at build
 # time). Key material is bind-mounted read-only at $GPG_SRC_DIR (default
-# /run/host-gpg) and the passphrase comes from the MY_GPG_PASSWORD env var, both
+# /run/host-gpg) and the passphrase comes from the GPG_PASSPHRASE env var, both
 # injected by `make run-go`. Skipped if absent. Nothing is baked into the image.
 
 set -uo pipefail
 
 GPG_SRC_DIR="${GPG_SRC_DIR:-/run/host-gpg}"
 
-if [ -s "${GPG_SRC_DIR}/secret.key" ] && [ -s "${GPG_SRC_DIR}/ownertrust.txt" ] && [ -n "${MY_GPG_PASSWORD:-}" ]; then
+if [ -s "${GPG_SRC_DIR}/secret.key" ] && [ -s "${GPG_SRC_DIR}/ownertrust.txt" ] && [ -n "${GPG_PASSPHRASE:-}" ]; then
     if gpg --list-secret-keys 2>/dev/null | grep -q '^sec'; then
         echo "GPG secret key already present — skipping import."
     else
         echo "Importing operator GPG key from ${GPG_SRC_DIR} (runtime mount)..."
         # https://unix.stackexchange.com/questions/60213
-        echo "$MY_GPG_PASSWORD" | gpg --batch --yes --passphrase-fd 0 --import "${GPG_SRC_DIR}/secret.key"
+        echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --import "${GPG_SRC_DIR}/secret.key"
         gpg --import-ownertrust "${GPG_SRC_DIR}/ownertrust.txt"
         gpg --list-secret-keys --keyid-format=long || true
     fi

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,11 @@
       "description": "Hold major updates for a 3-day stability buffer before opening a PR",
       "matchUpdateTypes": ["major"],
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "ubuntu is tracked as a TAG/version string (the published image tag + UBUNTU_VERSION build ARGs in Makefile/java/go Dockerfiles), NOT a pullable image ref, so digest-pinning does not apply. config:best-practices pulls in docker:pinDigests (global pinDigests=true), which kept erroring the `Pin dependencies` branch trying to append @sha256 to `docker-ubuntu-base:26.04` (a tag that cannot carry a digest). The base image's own FROM digest is managed separately by the UBUNTU_DIGEST customManager, so disabling pin here is safe.",
+      "matchDepNames": ["ubuntu"],
+      "pinDigests": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

Environment-variable consistency + the upgrade-analysis Wave 2 fix.

### Env var renames (consistent, vendor-neutral, professional)
| Before | After | Why |
|---|---|---|
| `MY_GPG_PASSWORD` | `GPG_PASSPHRASE` | drop personal `MY_` prefix; *passphrase* is GPG's own term (code uses `--passphrase-fd`) |
| `DOCKER_REGISTRY` | `IMAGE_REGISTRY` | vendor-neutral OCI term; pairs with `REGISTRY_OWNER`; works for podman/buildah/skopeo |
| `DOTFILES_DIR` | `GPG_SECRET_KEY_FILE` + `GPG_OWNERTRUST_FILE` | it was GPG-only **and** filenames were hardcoded to the owner → not portable. Explicit file-path vars are self-documenting and let any user point at their own export |
| `GITHUB_PAT` | *(kept)* | must be a GitHub PAT; used for ghcr.io login **and** github.com `.netrc` — genericizing would lose that meaning |

Renamed throughout `Makefile`, `README.md`, `CLAUDE.md`, `go/scripts/generate-gpg-keys.sh`.

### Remove dead/insecure `go/build.sh`
Unreferenced; pinned Ubuntu `21.10` (EOL); passed SSH **private key** + GPG **secret key** + PAT as `--build-arg` (bakes secrets into image history + argv). The current go image is credential-free with runtime injection, so it also no longer matched the Dockerfile. Replaced its intent with a **secure, validated** "Go dev container with credentials" example in the README (env-by-name + read-only bind-mounts, placeholders only).

### Fix errored Renovate `Pin dependencies` branch (upgrade-analysis Wave 2)
`config:best-practices` pulls in `docker:pinDigests` (global `pinDigests=true`), which kept trying to append `@sha256` to the `ubuntu` **tag** refs (`UBUNTU_VERSION` in Makefile/java/go Dockerfiles) → "update failure" (`docker-ubuntu-base:26.04` is a published tag that can't carry a digest). Added `pinDigests: false` for depName `ubuntu`; the real `FROM` digest stays managed by the dedicated `UBUNTU_DIGEST` customManager.

## Test plan
- [x] `make lint` (hadolint) — green
- [x] `make renovate-validate` — schema valid
- [x] `make -n run-go` proves `GPG_SECRET_KEY_FILE`/`GPG_OWNERTRUST_FILE` → `/run/host-gpg/*:ro` and `-e GITHUB_PAT`/`-e GPG_PASSPHRASE` (name-only, no values in argv)
- [x] `renovate --dry-run`: **4 `pinDigest` updates → 0**, `pin-dependencies` branch no longer generated
- [x] no real credential values introduced (placeholders only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)